### PR TITLE
fix(community/services): 修正按鈕底色與移除 section 小標籤

### DIFF
--- a/assets/styles/ocf-services.css
+++ b/assets/styles/ocf-services.css
@@ -127,7 +127,8 @@
   color: #fff;
 }
 .os-btn-hero-o {
-  border: 2px solid rgba(255, 255, 255, .3);
+  border: 2px solid rgba(255, 255, 255, .6);
+  background: rgba(255, 255, 255, .15);
   color: #fff;
   padding: 15px 30px;
   border-radius: 12px;
@@ -139,8 +140,8 @@
   transition: all .2s;
 }
 .os-btn-hero-o:hover {
-  border-color: rgba(255, 255, 255, .7);
-  background: rgba(255, 255, 255, .08);
+  border-color: rgba(255, 255, 255, .9);
+  background: rgba(255, 255, 255, .25);
   color: #fff;
 }
 .os-hero-note {

--- a/p/community/services.html
+++ b/p/community/services.html
@@ -35,7 +35,6 @@ css: ocf-services.css
 <section class="os-section" id="services">
   <div class="os-container">
     <div class="os-sec-head">
-      <div class="os-sec-tag">服務項目</div>
       <h2 class="os-sec-h">你需要的，我們都有</h2>
       <p class="os-sec-sub">從財務金流到法人代表，OCF 提供完整的行政支援，讓社群聚焦在開放文化推廣。</p>
     </div>
@@ -118,7 +117,6 @@ css: ocf-services.css
   <div class="os-container">
     <div class="os-fiscal-box">
       <div>
-        <div class="os-fiscal-tag">什麼是財務代管？</div>
         <h2>社群不用成立組織，<br>也能合法運作</h2>
         <p>財務代管（Fiscal Hosting / Fiscal Sponsorship）讓你的社群透過 OCF 的法人身分與銀行帳戶運作，而不必自行成立基金會或社團法人。OCF 提供行政服務、監督與支援，你的社群專注在使命。</p>
         <a class="os-fiscal-btn" href="https://docs.google.com/document/d/1VV9bS8VjILJBE9VV4qYjbBT3LRpokjCyeat59UGe6-Q/edit" target="_blank" rel="noopener">閱讀完整服務說明 →</a>
@@ -162,7 +160,6 @@ css: ocf-services.css
   <div class="os-container">
     <div class="os-split">
       <div class="os-split-text">
-        <div class="os-sec-tag">收入管理</div>
         <h2>多元管道，<br>讓資金順利進來</h2>
         <p>無論是個人捐款、企業贊助、活動售票或補助款，OCF 提供對應的收款工具，確認入帳後整理至社群帳表，並開立合適的稅務單據。</p>
         <div class="os-split-features">
@@ -222,7 +219,6 @@ css: ocf-services.css
   <div class="os-container">
     <div class="os-split reverse">
       <div class="os-split-text">
-        <div class="os-sec-tag">支出核銷</div>
         <h2>快速報帳，<br>準時收到款項</h2>
         <p>社群窗口整理並預先確認單據後，送至 OCF；OCF 確認後，每月第一及第三個週四撥款。合法單據涵蓋發票、交通、勞務等多種類型。</p>
         <div class="os-split-features">
@@ -272,7 +268,6 @@ css: ocf-services.css
   <div class="os-container">
     <div class="os-split">
       <div class="os-split-text">
-        <div class="os-sec-tag">帳務透明</div>
         <h2>對社群誠實，<br>對外公開清楚</h2>
         <p>OCF 秉持開放透明的精神，每月提供帳表給社群負責人確認。社群可選擇將帳務公開，提升贊助者信心，展現真實的財務狀況。</p>
         <div class="os-split-features">
@@ -326,7 +321,6 @@ css: ocf-services.css
 <section class="os-section" id="communities">
   <div class="os-container">
     <div class="os-sec-head center">
-      <div class="os-sec-tag">合作社群</div>
       <h2 class="os-sec-h">已有這些社群在使用</h2>
       <p class="os-sec-sub">來自不同領域的開放文化社群，依各自需求組合 OCF 的服務。</p>
     </div>
@@ -419,7 +413,6 @@ css: ocf-services.css
 <section class="os-section os-section-alt">
   <div class="os-container">
     <div class="os-sec-head">
-      <div class="os-sec-tag">申請資格</div>
       <h2 class="os-sec-h">哪些社群符合資格？</h2>
       <p class="os-sec-sub">OCF 主要服務推廣開放文化的社群組織，以下是基本的申請條件說明。</p>
     </div>
@@ -453,7 +446,6 @@ css: ocf-services.css
 <section class="os-section" id="apply">
   <div class="os-container">
     <div class="os-sec-head center">
-      <div class="os-sec-tag">申請流程</div>
       <h2 class="os-sec-h">四步驟開始合作</h2>
       <p class="os-sec-sub">從送出申請到正式啟用服務，整個過程清楚透明。</p>
     </div>


### PR DESCRIPTION
## 變更內容

### 按鈕底色修正
- 「瞭解服務內容」按鈕（`.os-btn-hero-o`）原本底色透明，在深紫 hero 背景下文字辨識度不足
- 加入 `background: rgba(255,255,255,.15)` 半透明白底
- 加深 border 至 `rgba(255,255,255,.6)`（原為 `.3`）
- hover 狀態同步加強

### 移除 section 小標籤
移除頁面各區塊的小框標籤元素（`os-sec-tag` / `os-fiscal-tag`）：
- 服務項目、什麼是財務代管、收入管理、支出核銷、帳務透明、合作社群、申請資格、申請流程

## 測試
視覺調整，可直接於預覽頁確認。