### PR TITLE
SEO: add Organization & BreadcrumbList JSON-LD (#107)

### DIFF
--- a/_includes/_var/jsonld/breadcrumb.html
+++ b/_includes/_var/jsonld/breadcrumb.html
@@ -1,0 +1,109 @@
+{%- comment -%}
+  BreadcrumbList JSON-LD。
+  依下列順序決定 breadcrumb 內容：
+    1. page.breadcrumb（front matter 陣列，items: [{name, url}]）→ 直接使用
+    2. 自動產生：首頁 → 區段（依 URL 第一段對應，可選） → 當前頁
+  首頁本身不輸出 breadcrumb。
+  必須在 og/ include 之後執行（會用到 og_title）。
+{%- endcomment -%}
+
+{%- assign url = page.url -%}
+{%- assign is_home = false -%}
+{%- if url == '/' or url == '/index.html' or url == '/en/' or url == '/en/index.html' -%}
+  {%- assign is_home = true -%}
+{%- endif -%}
+
+{%- unless is_home -%}
+
+{%- if lang == 'en' -%}
+  {%- assign home_name = 'Home' -%}
+  {%- assign home_url = '/en/' -%}
+{%- else -%}
+  {%- assign home_name = '首頁' -%}
+  {%- assign home_url = '/' -%}
+{%- endif -%}
+
+{%- comment -%} 從 URL 推斷區段（中介層） {%- endcomment -%}
+{%- assign segments = url | remove_first: '/en' | split: '/' -%}
+{%- assign first_seg = segments[1] -%}
+{%- assign section_name = '' -%}
+{%- assign section_url = '' -%}
+
+{%- if lang == 'en' -%}
+  {%- case first_seg -%}
+    {%- when 'p' -%}{%- assign section_name = 'Projects' -%}{%- assign section_url = '/en/p/' -%}
+    {%- when 'about' -%}{%- assign section_name = 'About' -%}{%- assign section_url = '/en/about/' -%}
+    {%- when 'people' -%}{%- assign section_name = 'People' -%}{%- assign section_url = '/en/people/' -%}
+    {%- when 'journal' -%}{%- assign section_name = 'Events' -%}{%- assign section_url = '/en/journal/' -%}
+    {%- when 'news' -%}{%- assign section_name = 'News' -%}{%- assign section_url = '/en/news/' -%}
+    {%- when 'story' -%}{%- assign section_name = 'Stories' -%}{%- assign section_url = '/en/story/' -%}
+    {%- when 'supportus' -%}{%- assign section_name = 'Support Us' -%}{%- assign section_url = '/en/supportus/' -%}
+    {%- when 'mediakit' -%}{%- assign section_name = 'Mediakit' -%}{%- assign section_url = '/en/mediakit/' -%}
+    {%- when 'jobs' -%}{%- assign section_name = 'Jobs' -%}{%- assign section_url = '/en/jobs/' -%}
+    {%- when 'join' -%}{%- assign section_name = 'Join' -%}{%- assign section_url = '/en/join/' -%}
+    {%- when 'design' -%}{%- assign section_name = 'Design System' -%}{%- assign section_url = '/en/design/' -%}
+  {%- endcase -%}
+{%- else -%}
+  {%- case first_seg -%}
+    {%- when 'p' -%}{%- assign section_name = '專案' -%}{%- assign section_url = '/p/' -%}
+    {%- when 'about' -%}{%- assign section_name = '關於' -%}{%- assign section_url = '/about/' -%}
+    {%- when 'people' -%}{%- assign section_name = '工作夥伴' -%}{%- assign section_url = '/people/' -%}
+    {%- when 'journal' -%}{%- assign section_name = '活動' -%}{%- assign section_url = '/journal/' -%}
+    {%- when 'news' -%}{%- assign section_name = '電子報' -%}{%- assign section_url = '/news/' -%}
+    {%- when 'story' -%}{%- assign section_name = '文章' -%}{%- assign section_url = '/story/' -%}
+    {%- when 'supportus' -%}{%- assign section_name = '捐款支持' -%}{%- assign section_url = '/supportus/' -%}
+    {%- when 'mediakit' -%}{%- assign section_name = '媒體區' -%}{%- assign section_url = '/mediakit/' -%}
+    {%- when 'jobs' -%}{%- assign section_name = '徵才' -%}{%- assign section_url = '/jobs/' -%}
+    {%- when 'join' -%}{%- assign section_name = '加入我們' -%}{%- assign section_url = '/join/' -%}
+    {%- when 'design' -%}{%- assign section_name = '設計系統' -%}{%- assign section_url = '/design/' -%}
+  {%- endcase -%}
+{%- endif -%}
+
+{%- assign current_name = og_title | default: page.title | default: page.name -%}
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {%- if page.breadcrumb -%}
+      {%- for item in page.breadcrumb -%}
+    {
+      "@type": "ListItem",
+      "position": {{ forloop.index }},
+      "name": "{{ item.name | escape }}"{% if item.url %},
+      "item": "{{ item.url | absolute_url }}"{% endif %}
+    }{%- unless forloop.last -%},{%- endunless -%}
+      {%- endfor -%}
+    {%- else -%}
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "{{ home_name }}",
+      "item": "{{ home_url | absolute_url }}"
+    }
+    {%- if section_name != '' and section_url != url -%},
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "{{ section_name }}",
+      "item": "{{ section_url | absolute_url }}"
+    }
+    {%- assign current_position = 3 -%}
+    {%- else -%}
+    {%- assign current_position = 2 -%}
+    {%- endif -%}
+    {%- if current_name and current_name != '' -%},
+    {
+      "@type": "ListItem",
+      "position": {{ current_position }},
+      "name": "{{ current_name | escape }}",
+      "item": "{{ url | absolute_url }}"
+    }
+    {%- endif -%}
+    {%- endif -%}
+  ]
+}
+</script>
+
+{%- endunless -%}

--- a/_includes/_var/jsonld/organization.html
+++ b/_includes/_var/jsonld/organization.html
@@ -1,0 +1,66 @@
+{%- comment -%}
+  全站 Organization (NGO) JSON-LD。資料來源：_data/people/orgs/ocf.yml
+  schema.org NGO type，附兩個辦公室的 PostalAddress（涵蓋 issue #107 提到的 LocalBusiness 需求）。
+{%- endcomment -%}
+{%- assign org = site.data.people.orgs.ocf -%}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NGO",
+  "@id": "{{ site.url }}/#organization",
+  "name": "{{ org.name }}",
+  "alternateName": ["{{ org.name_en }}", "{{ org.abbr }}", "{{ org.abbr_en }}"],
+  "url": "{{ site.url }}/",
+  "logo": "{{ org.logo | absolute_url }}",
+  "image": "{{ org.cover | absolute_url }}",
+  "description": "{{ org.description | strip_newlines | escape }}",
+  "foundingDate": "2014-06",
+  "foundingLocation": "Taiwan",
+  "email": "{{ org.contact.email.general }}",
+  "sameAs": [
+    "https://www.facebook.com/www.ocf.tw",
+    "https://www.instagram.com/ocftw/",
+    "https://www.youtube.com/c/OcfTw",
+    "https://g0v.social/@ocftw",
+    "https://www.flickr.com/people/ocftw/",
+    "https://github.com/ocftw",
+    "https://blog.ocf.tw/"
+  ],
+  "location": [
+    {
+      "@type": "Place",
+      "name": "Taipei Office",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "八德路四段 636 之 1 號",
+        "addressLocality": "松山區",
+        "addressRegion": "臺北市",
+        "postalCode": "105057",
+        "addressCountry": "TW"
+      },
+      "telephone": "+886-2-2395-1505"
+    },
+    {
+      "@type": "Place",
+      "name": "Taoyuan Office",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "中山路 807 號",
+        "addressLocality": "桃園區",
+        "addressRegion": "桃園市",
+        "postalCode": "33059",
+        "addressCountry": "TW"
+      },
+      "telephone": "+886-3-220-7480",
+      "faxNumber": "+886-3-220-1542"
+    }
+  ],
+  "contactPoint": {
+    "@type": "ContactPoint",
+    "contactType": "general inquiries",
+    "email": "{{ org.contact.email.general }}",
+    "telephone": "+886-2-2395-1505",
+    "availableLanguage": ["zh-Hant", "en"]
+  }
+}
+</script>

--- a/_layouts/global.html
+++ b/_layouts/global.html
@@ -97,18 +97,8 @@
   {% endif %}
 <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ site.url }}/feed.xml">
 
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "EducationalOrganization",
-  "name": "財團法人開放文化基金會 (OCF)",
-  "url": "https://ocf.tw/",
-  "description": "台灣開源社群共同發起的非營利基金會，推動開放原始碼、開放資料、開放政府、數位人權與網路自由。",
-  "alternateName": "Open Culture Foundation (OCF)",
-  "image": "https://ocf.tw/mediakit/cover.png",
-  "sameAs": "https://aeo.washinmura.jp/aeo/shops/ocf-tw/llms.txt"
-}
-</script>
+{% include _var/jsonld/organization.html %}
+{% include _var/jsonld/breadcrumb.html %}
 
 <script type="application/ld+json">
 {


### PR DESCRIPTION
## Summary
- 新增 `_includes/_var/jsonld/organization.html`,改用 `_data/people/orgs/ocf.yml` 動態產出 schema.org **NGO** JSON-LD,並把台北、桃園兩個辦公室地址放進 `location`,涵蓋 issue 提到的 LocalBusiness 需求(NGO type 對基金會比 LocalBusiness 更精確,Google 也認 NGO + location)。
- 新增 `_includes/_var/jsonld/breadcrumb.html`,輸出 schema.org **BreadcrumbList**。依 `page.url` 第一段自動產生「首頁 → 區段 → 當前頁」,zh/en 各別對應 `/p`、`/about`、`/people`、`/journal`、`/news`、`/story`、`/supportus`、`/mediakit`、`/jobs`、`/join`、`/design`,首頁本身不輸出。任何頁面也可用 front matter 的 `breadcrumb:` 陣列覆寫。
- `_layouts/global.html` 改 `include` 上述兩個檔,移除原本 hard-code 在 head 裡的 `EducationalOrganization` JSON-LD(那段裡有個與 OCF 無關的第三方 `sameAs` 連結 `aeo.washinmura.jp`,順手清掉)。

FAQPage 那段 JSON-LD 保留不動,不在本 PR 範圍。

Resolves #107

## Test plan
- [ ] 本機 `./run_docker.sh` 起 Jekyll,任選幾個頁面檢查 `<head>` 中是否輸出兩段新的 `application/ld+json`,且舊的 EducationalOrganization 已不存在
- [ ] 驗證頁面類型(每個 layout 至少一個):首頁(`/`、`/en/`)應**不**輸出 BreadcrumbList;`/p/g0v/`、`/journal/...`、`/about/...`、`/people/`、`/supportus/`、`/mediakit/...`、`/story/...` 應輸出三層
- [ ] Google [Rich Results Test](https://search.google.com/test/rich-results) 對 production URL 跑一輪(部署後)驗證 Organization 與 Breadcrumb 兩種類型都被偵測到且無 error
- [ ] Schema.org [Validator](https://validator.schema.org/) 對同上頁面再跑一次,確認語法

🤖 Generated with [Claude Code](https://claude.com/claude-code)