### PR TITLE
Add July 2026 Internet Freedom meetup

### DIFF
--- a/_data/p/infr/events.yml
+++ b/_data/p/infr/events.yml
@@ -14,6 +14,8 @@
       url: https://summit.g0v.tw/2026/agenda/day1/#2026-033
     - title: TAKKE.ME - 災防、搜救、通訊知識交流平台
       url: https://ocftw.kktix.cc/events/internetfreedom-jun2026
+    - title: 身分證換號法說會
+      url: https://ocftw.kktix.cc/events/internetfreedom-jul2026
   cover_image: /p/issues/C&C-events.png
   contributor_ids: 
     - rock


### PR DESCRIPTION
## What changed

- Add「身分證換號法說會」to the 2026 Internet Freedom meetup links.
- Link the event to its KKTIX registration page.

## Why

The July 2026 meetup needs to appear on the Internet Freedom project page.

## Validation

- `bundle exec jekyll build --destination /private/tmp/ocf-event-preview`
