### PR TITLE
Refine news category filters

### DIFF
--- a/assets/styles/story.css
+++ b/assets/styles/story.css
@@ -58,68 +58,58 @@
   background: rgba(255, 255, 255, 0.9) !important;
 }
 
-.story-filter-panel {
+.story-filter-bar {
   margin: 1rem 0 1.5rem;
-  padding: 1rem;
-  border: 1px solid rgba(34, 36, 38, 0.12);
-  border-radius: 0.5rem;
-  background: #fafafa;
+  padding: 1rem 0 1.25rem;
+  border-bottom: 1px solid rgba(34, 36, 38, 0.12);
+}
+
+.story-filter-bar__topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
 }
 
 .story-filter-heading {
-  margin-bottom: 0.75rem;
-  color: #555;
+  color: #333;
   font-weight: 700;
 }
 
 .story-filter-buttons {
-  display: grid !important;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
-  width: 100%;
 }
 
-.story-filter-buttons .button {
-  display: flex !important;
-  align-items: center;
-  justify-content: center;
-  margin: 0 !important;
-  min-height: 3.25rem;
-  width: 100%;
-  line-height: 1.35;
-  text-align: center;
-  white-space: normal;
-  border-radius: 0.28571429rem !important;
+.story-filter {
+  padding: 0.62rem 0.9rem;
+  border: 0;
+  border-radius: 999px;
+  color: #514d61;
+  background: #f1f0f6;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.88rem;
+  line-height: 1.15;
+  transition: color 160ms ease, background-color 160ms ease, transform 160ms ease;
 }
 
-@media only screen and (max-width: 767px) {
-  .story-filter-buttons {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+.story-filter:hover {
+  color: #4e3cc4;
+  background: #e7e3ff;
+  transform: translateY(-1px);
 }
 
-@media only screen and (max-width: 420px) {
-  .story-filter-buttons {
-    grid-template-columns: 1fr;
-  }
-}
-
-.story-filter-buttons .story-filter.basic {
-  color: #6450dc !important;
-  background: transparent !important;
-  box-shadow: 0 0 0 1px #6450dc inset !important;
-}
-
-.story-filter-buttons .story-filter.active {
-  color: #fff !important;
-  background-color: #6450dc !important;
-  box-shadow: none !important;
+.story-filter.active {
+  color: #fff;
+  background: #6450dc;
 }
 
 .story-filter-summary {
-  margin-top: 0.75rem;
   color: #777;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
+  white-space: nowrap;
 }
 
 .story-list-taxonomy {
@@ -135,4 +125,11 @@
 
 .story-article-item[hidden] {
   display: none !important;
+}
+
+@media only screen and (max-width: 420px) {
+  .story-filter {
+    padding: 0.55rem 0.72rem;
+    font-size: 0.8rem;
+  }
 }

--- a/story/menu/articles/index.md
+++ b/story/menu/articles/index.md
@@ -28,16 +28,19 @@ toc: false
         {% endunless %}
       {% endfor %}
 
-      <div class="story-filter-panel" aria-label="文章分類篩選">
-        <div class="story-filter-heading">依 TAG 瀏覽</div>
-        <div class="ui small buttons story-filter-buttons">
-          <button type="button" class="ui button story-filter active" data-filter-type="all" data-filter-value="">
-            全部文章
+      <nav class="story-filter-bar" aria-label="文章分類篩選">
+        <div class="story-filter-bar__topline">
+          <div class="story-filter-heading">文章分類</div>
+          <div id="story-filter-summary" class="story-filter-summary" aria-live="polite"></div>
+        </div>
+        <div class="story-filter-buttons">
+          <button type="button" class="story-filter active" data-filter-type="all" data-filter-value="">
+            全部
           </button>
           {% for category in story_categories %}
           <button
             type="button"
-            class="ui basic button story-filter"
+            class="story-filter"
             data-filter-type="category"
             data-filter-value="{{ category | escape }}"
           >
@@ -45,8 +48,7 @@ toc: false
           </button>
           {% endfor %}
         </div>
-        <div id="story-filter-summary" class="story-filter-summary" aria-live="polite"></div>
-      </div>
+      </nav>
 
       <div class="ui relaxed divided list">
       {% assign new_articles = "" | split: "," %}
@@ -132,7 +134,6 @@ toc: false
                 button.dataset.filterType === type &&
                 button.dataset.filterValue === value;
               button.classList.toggle('active', isActive);
-              button.classList.toggle('basic', !isActive);
             });
           }
 
@@ -151,8 +152,8 @@ toc: false
             setActiveButton(type, value);
             filterSummary.textContent =
               type === 'all'
-                ? `共 ${visibleCount} 篇文章`
-                : `「${value}」共有 ${visibleCount} 篇文章`;
+                ? `共 ${visibleCount} 篇`
+                : `${visibleCount} 篇`;
 
             if (type !== 'all') {
               olderAccordion.accordion('open', 0);


### PR DESCRIPTION
## What changed

- Replace the large grid-style category controls with compact wrapping pill tags.
- Rename the filter heading to「文章分類」and shorten the all-items label to「全部」.
- Keep the article count beside the heading and preserve URL-based category filtering.
- Leave the page hero, article list, media coverage, and surrounding layout unchanged.

## Why

The previous category controls occupied a large block above the article list and visually resembled form buttons. Compact tags make the available categories easier to scan while retaining the existing filtering behavior.

## Validation

- `bundle exec jekyll build`
- Tested category selection and article counts in the local preview.
- Checked desktop and mobile layouts for horizontal overflow.
- Confirmed no browser console warnings or errors.
