### PR TITLE
改善資安陪伴計畫中英文專案頁

### DIFF
--- a/_data/p/defendhrd/events.yml
+++ b/_data/p/defendhrd/events.yml
@@ -1,16 +1,19 @@
 - id: civil-society-digital-frontline-2026
   name: "公民社會的數位防線：共同面對數位威脅"
   name_en:
-  description: "OCF 將於 2026 年 7 月 20 日舉辦數位安全論壇，發表兩份聚焦台灣公民社會數位威脅的研究報告，分享資安陪伴計畫觀察與近期攻擊案例，並邀請國家安全會議、黑熊民防教育協會、Cisco Talos、CSCS 等講者，共同討論公民社會如何理解、辨識並回應數位威權與數位攻擊。"
+  description: "OCF 於 2026 年 7 月 20 日舉辦數位安全論壇，發表兩份聚焦台灣公民社會數位威脅的研究報告，分享資安陪伴計畫觀察與近期攻擊案例，並邀請國家安全會議、黑熊民防教育協會、Cisco Talos、CSCS 等講者，共同討論公民社會如何理解、辨識並回應數位威權與數位攻擊。"
   start: 2026/07/20
   end:
   metas:
     - 時間：14:30–17:10（14:00 開放報到）
     - 地點：BEONE 未來共生基地（台北市信義區基隆路一段 200 號 B1F）
   links:
-    - title: 最新消息
-      url: /story/civil-society-digital-frontline-2026/
-    - title: KKTIX 報名
+    - title: 活動紀錄
+      url: /story/digital-security-forum-2026/
+      icon: file alternate outline
+    - title: HackMD 共筆
+      url: https://hackmd.io/k4QsLA_bSMWqzLbS9lELGA
+    - title: KKTIX 報名（已截止）
       url: https://ocftw.kktix.cc/events/2026digitalfronline
   cover_image: /story/civil-society-digital-frontline-2026/images/digital-frontline-square.png
   banner_image: /story/civil-society-digital-frontline-2026/images/digital-frontline-square.png

--- a/_data/p/defendhrd/project.yml
+++ b/_data/p/defendhrd/project.yml
@@ -43,19 +43,19 @@ links:
     color: 
     icon: world icon
 links_en:
-  - title: 【Report】Digital Security Mapping for HRDs in Taiwan
+  - title: "[Report] Digital Security Mapping for HRDs in Taiwan"
     url: https://drive.google.com/file/d/1VV12Rp7IKkWexNTKQRuWIA4Zfd8ztN9X/view?usp=drive_link
     color: 
     icon: file outline
-  - title: "【Report】Safeguarding Advocacy: A Security Makeover Program (SMP) for CSOs and HRDs"
+  - title: "[Report] Safeguarding Advocacy"
     url: https://drive.google.com/file/d/1ln6__KiGZgf9QSkYhwKo8gm4L9d9tExo/view?usp=drive_link
     color: 
     icon: file outline
-  - title: "【Report】The Cost of Trust: Lessons from a Cyberattack on Taiwan-Based Human Rights Defenders"
+  - title: "[Report] The Cost of Trust"
     url: https://drive.google.com/file/d/1Q3Z2nLJ4dkQpmSqXQcctl4IW3cUhdDkF/view?usp=drive_link
     color: 
     icon: file outline
-  - title: 【Learning Material】Shield of Self-Defense (SSD)
+  - title: "[Learning Resource] Shield of Self-Defense (SSD)"
     url: https://ssd.ocf.tw/
     color: 
     icon: world icon

--- a/en/p/defendhrd/index.html
+++ b/en/p/defendhrd/index.html
@@ -33,16 +33,23 @@ show_child_projects: yes
 <h2 class="ui dividing header">Reports &amp; Resources</h2>
 <p>The project produced three public reports and one learning resource. Together, these outputs document digital threat trends, the <strong>Security Makeover Program</strong> experience, practical learning materials, and a real-world cyberattack case, offering useful insights for NGOs and digital security practitioners working to strengthen civil society’s digital resilience.</p>
 
-<h3 class="ui header">Digital Security Mapping for HRDs in Taiwan: Preliminary Results (2024)</h3>
-<p>Based on 35 survey responses and 3 in-depth interviews, this report maps <strong>key digital threats</strong> facing Taiwan-based CSOs and HRDs, including phishing, online harassment, account compromise, and infrastructure attacks. It highlights why resource-limited CSOs need long-term digital security support.</p>
-
-<h3 class="ui header">Safeguarding Advocacy: A <strong>Security Makeover Program</strong> (SMP) for CSOs and HRDs (2026)</h3>
-<p>This report documents OCF’s one-year <strong>Security Makeover Program</strong> with 6 high-risk CSOs and HRD groups. It shares how long-term accompaniment helped organizations review daily digital practices and develop practical security policies or guidelines.</p>
-
-<h3 class="ui header">The Cost of Trust: Lessons from a Cyberattack on Taiwan-Based Human Rights Defenders (2026)</h3>
-<p>This report examines <strong>the MAK case</strong>, a real cyberattack in which attackers impersonated a Taiwanese human rights organization to target its partners. It shows how civil society trust networks can be exploited—and how timely reporting, OCF coordination, and CSCS technical support helped stop the attack before infection.</p>
+<ul class="report-summaries">
+  <li><span class="report-title"><strong><em>Digital Security Mapping for HRDs in Taiwan: Preliminary Results</em></strong> (2024)</span><span class="report-description">Based on 35 survey responses and 3 in-depth interviews, this report maps key digital threats facing Taiwan-based CSOs and HRDs, including phishing, online harassment, account compromise, and infrastructure attacks. It highlights why resource-limited CSOs need long-term digital security support.</span></li>
+  <li><span class="report-title"><strong><em>Safeguarding Advocacy: A Security Makeover Program (SMP) for CSOs and HRDs</em></strong> (2026)</span><span class="report-description">This report documents OCF’s one-year Security Makeover Program with 6 high-risk CSOs and HRD groups. It shares how long-term accompaniment helped organizations review daily digital practices and develop practical security policies or guidelines.</span></li>
+  <li><span class="report-title"><strong><em>The Cost of Trust: Lessons from a Cyberattack on Taiwan-Based Human Rights Defenders</em></strong> (2026)</span><span class="report-description">This report examines the MAK case, a real cyberattack in which attackers impersonated a Taiwanese human rights organization to target its partners. It shows how civil society trust networks can be exploited—and how timely reporting, OCF coordination, and CSCS technical support helped stop the attack before infection.</span></li>
+</ul>
 
 <style>
+  .report-summaries .report-title,
+  .report-summaries .report-description {
+    display: block;
+  }
+  .report-summaries .report-title {
+    margin-bottom: 0.5em;
+  }
+  .report-summaries li + li {
+    margin-top: 1em;
+  }
   .defendhrd-results .download-section {
     display: flex; justify-content: center; gap: 40px;
     flex-wrap: wrap; margin: 30px 0 40px;
@@ -67,7 +74,24 @@ show_child_projects: yes
     border-radius: 20px; font-size: 0.9rem; text-decoration: none;
   }
   .defendhrd-results a.btn-download:hover { color: #ffffff !important; opacity: 0.9; }
+  #project #links a[href="https://ssd.ocf.tw/"] {
+    position: relative;
+    left: -0.25em;
+  }
+  #project #meta .ocf__heading3,
+  #project #meta > .meta__section:first-of-type p,
+  #project #meta #cast dt,
+  #project #meta #cast dd,
+  #project #links .item {
+    font-size: 0.875rem;
+    line-height: 1.5;
+  }
   @media (max-width: 768px) {
+    #project .project__body > div > p,
+    #project .defendhrd-results .card-desc {
+      font-size: 1rem;
+      line-height: 1.6;
+    }
     .defendhrd-results .download-card {
       width: 100%;
       max-width: 300px;

--- a/p/defendhrd/index.html
+++ b/p/defendhrd/index.html
@@ -31,13 +31,23 @@ show_child_projects: yes
 
 <h2 class="ui dividing header">研究成果與資源</h2>
 
-<ul>
-  <li>《台灣人權民主倡議團體數位威脅概況》（2024）<br>本報告透過 35 份問卷與 3 份深度訪談，了解在臺灣的人權與民主倡議團體面對哪些數位威脅。研究發現，許多組織規模小、人力有限，卻經常面對社群媒體騷擾、釣魚攻擊、帳號或資料受損等風險。報告也指出，許多團體的數位工具與工作流程多半是因應需求臨時拼湊而成，缺乏完整規劃，因此更難面對持續升高的攻擊風險。</li>
-  <li>《守護倡議之聲：公民團體與人權工作者<strong>資安陪伴計畫</strong>成果報告》（2026）<br>本報告整理 OCF 一年期「<strong>資安陪伴計畫</strong>」的執行過程與成果。計畫陪伴 6 個高風險公民團體與人權工作者組織，協助他們檢視日常使用的工具、帳號、資料與工作流程，並建立可執行的資安政策或守則。報告也整理陪伴過程中的經驗，包括如何建立信任、如何讓資安成為組織日常，以及如何在有限資源下逐步提升防護能力。</li>
-  <li>《信任的代價：一場針對臺灣人權工作者的資安攻擊與防守實錄》（2026）<br>本報告記錄一場<strong>針對臺灣人權工作者與其合作網絡的資安攻擊</strong>。攻擊者冒用人權組織 MAK 的名義，寄出高度擬真的釣魚郵件，企圖利用該組織累積的信任，進一步攻擊合作夥伴。事件最後在感染前被成功攔截，關鍵在於外部夥伴察覺異常、MAK 即時通報 OCF，並由 CSCS 資安社群協助分析。報告提醒，公民社會需要更穩定的通報與防禦機制。</li>
+<ul class="report-summaries">
+  <li><span class="report-title">《台灣人權民主倡議團體數位威脅概況》（2024）</span><span class="report-description">本報告透過 35 份問卷與 3 份深度訪談，了解在臺灣的人權與民主倡議團體面對哪些數位威脅。研究發現，許多組織規模小、人力有限，卻經常面對社群媒體騷擾、釣魚攻擊、帳號或資料受損等風險。報告也指出，許多團體的數位工具與工作流程多半是因應需求臨時拼湊而成，缺乏完整規劃，因此更難面對持續升高的攻擊風險。</span></li>
+  <li><span class="report-title">《守護倡議之聲：公民團體與人權工作者<strong>資安陪伴計畫</strong>成果報告》（2026）</span><span class="report-description">本報告整理 OCF 一年期「資安陪伴計畫」的執行過程與成果。計畫陪伴 6 個高風險公民團體與人權工作者組織，協助他們檢視日常使用的工具、帳號、資料與工作流程，並建立可執行的資安政策或守則。報告也整理陪伴過程中的經驗，包括如何建立信任、如何讓資安成為組織日常，以及如何在有限資源下逐步提升防護能力。</span></li>
+  <li><span class="report-title">《信任的代價：一場針對臺灣人權工作者的資安攻擊與防守實錄》（2026）</span><span class="report-description">本報告記錄一場針對臺灣人權工作者與其合作網絡的資安攻擊。攻擊者冒用人權組織 MAK 的名義，寄出高度擬真的釣魚郵件，企圖利用該組織累積的信任，進一步攻擊合作夥伴。事件最後在感染前被成功攔截，關鍵在於外部夥伴察覺異常、MAK 即時通報 OCF，並由 CSCS 資安社群協助分析。報告提醒，公民社會需要更穩定的通報與防禦機制。</span></li>
 </ul>
 
 <style>
+  .report-summaries .report-title,
+  .report-summaries .report-description {
+    display: block;
+  }
+  .report-summaries .report-title {
+    margin-bottom: 0.5em;
+  }
+  .report-summaries li + li {
+    margin-top: 1em;
+  }
   .defendhrd-results .download-section {
     display: flex; justify-content: center; gap: 40px;
     flex-wrap: wrap; margin: 30px 0 40px;
@@ -62,7 +72,26 @@ show_child_projects: yes
     border-radius: 20px; font-size: 0.9rem; text-decoration: none;
   }
   .defendhrd-results a.btn-download:hover { color: #ffffff !important; opacity: 0.9; }
+  #project #links a[href="https://ssd.ocf.tw/"] {
+    position: relative;
+    left: -0.25em;
+  }
+  #project #meta .ocf__heading3,
+  #project #meta > .meta__section:first-of-type p,
+  #project #meta #cast dt,
+  #project #meta #cast dd,
+  #project #links .item {
+    font-size: 0.875rem;
+    line-height: 1.5;
+  }
   @media (max-width: 768px) {
+    #project .project__body > div > p,
+    #project .report-summaries li,
+    #project .defendhrd-results .card-desc,
+    #project .project-related-events .description p {
+      font-size: 1rem;
+      line-height: 1.6;
+    }
     .defendhrd-results .download-card {
       width: 100%;
       max-width: 300px;
@@ -79,7 +108,7 @@ show_child_projects: yes
     <div class="download-card">
       <img src="/p/defendhrd/Digital%20Security%20Mapping%20for%20HRDs%20in%20Taiwan.png" alt="台灣人權與民主倡議團體數位威脅概況" class="album-art">
       <h3>台灣人權與民主倡議團體數位威脅概況</h3>
-      <p class="card-desc">2024 年研究報告摘要（中文版），整理 35 份問卷與 3 場深度訪談中，在臺人權與民主倡議團體面臨的數位威脅樣態與資安需求。</p>
+      <p class="card-desc">透過 35 份問卷與 3 場深度訪談，瞭解在臺人權與民主倡議團體面臨的數位威脅樣態與資安需求。</p>
       <a href="https://drive.google.com/file/d/1sxAFmSiJL6DzdO3ezq_hJSBROuGXNLAA/view" class="btn-download">中文版</a>
       <a href="https://drive.google.com/file/d/1VV12Rp7IKkWexNTKQRuWIA4Zfd8ztN9X/view?usp=sharing" class="btn-download">英文版</a>
     </div>


### PR DESCRIPTION
## 變更內容

- 在相關活動新增活動紀錄與 HackMD 共筆，更新活動狀態與連結文案
- 統一中英文專案頁在手機及桌機的資訊欄字級與 icon 對齊
- 改善中英文報告摘要的間距、列點與標題樣式
- 更新英文相關連結名稱及中文 2024 報告卡片說明

## 目的與影響

改善中英文專案頁的閱讀層級、行動連結與響應式排版，使桌機與手機顯示更一致，並讓活動結束後的紀錄與資源更容易找到。

## 驗證

- YAML 解析檢查通過
- `git diff --check` 通過
- 使用本機 Jekyll 預覽檢查中英文頁面
- 檢查手機與 1200 × 900 桌機尺寸的字級、連結與 icon 對齊
