### PR TITLE
Add standalone internet freedom issue page

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -42,6 +42,8 @@ menu:
   - title: 核心倡議
     url:
     items:
+      - title: 網路自由
+        url: /internet-freedom/
       - title: 基金會專案
         url: /p/ocf
       - title: 十週年開源祭

--- a/_includes/p/infr-webm-header.html
+++ b/_includes/p/infr-webm-header.html
@@ -55,7 +55,7 @@
     <div class="infr-hero__actions">
       <button id="infr-webm-control" class="infr-route-control" type="button" aria-pressed="false">
         <span class="infr-route-control__dot" aria-hidden="true"></span>
-        讓訊號重新連上
+        <span class="infr-route-control__label">讓訊號重新連上</span>
       </button>
       <a class="infr-hero__link" href="#internet-freedom-content">了解我們的工作</a>
     </div>

--- a/_includes/p/infr-webm-header.html
+++ b/_includes/p/infr-webm-header.html
@@ -57,7 +57,7 @@
         <span class="infr-route-control__dot" aria-hidden="true"></span>
         讓訊號重新連上
       </button>
-      <a class="infr-hero__link" href="#project-content">了解我們的工作</a>
+      <a class="infr-hero__link" href="#internet-freedom-content">了解我們的工作</a>
     </div>
   </div>
 </section>

--- a/_layouts/internet-freedom.html
+++ b/_layouts/internet-freedom.html
@@ -1,0 +1,10 @@
+---
+layout: global
+---
+
+<main id="internet-freedom">
+  {% include p/infr-webm-header.html %}
+  <div id="internet-freedom-content" class="infr-story-page">
+    {{ content }}
+  </div>
+</main>

--- a/_layouts/p.html
+++ b/_layouts/p.html
@@ -18,19 +18,10 @@ layout: global
 
 <main id="project">
 
-{% if page.custom_header == 'infr-webm' %}
-{% include p/infr-webm-header.html %}
-{% else %}
 {% include p/header.html %}
-{% endif %}
 
 <!-- 主要區塊 -->
 
-{% if page.custom_header == 'infr-webm' %}
-<div id="project-content" class="infr-story-page">
-  {{ content }}
-</div>
-{% else %}
 <div class="page__container">
   <div class="page__spacer--xlarge"></div>
   <div class="page__grid project__body">
@@ -99,6 +90,5 @@ layout: global
   </div>
   <div class="ui hidden divider"></div>
 </div>
-{% endif %}
 
 </main>

--- a/_layouts/p.html
+++ b/_layouts/p.html
@@ -26,7 +26,12 @@ layout: global
 
 <!-- 主要區塊 -->
 
-<div class="page__container"{% if page.custom_header == 'infr-webm' %} id="project-content"{% endif %}>
+{% if page.custom_header == 'infr-webm' %}
+<div id="project-content" class="infr-story-page">
+  {{ content }}
+</div>
+{% else %}
+<div class="page__container">
   <div class="page__spacer--xlarge"></div>
   <div class="page__grid project__body">
 
@@ -94,5 +99,6 @@ layout: global
   </div>
   <div class="ui hidden divider"></div>
 </div>
+{% endif %}
 
 </main>

--- a/assets/scripts/infr-webm-demo.js
+++ b/assets/scripts/infr-webm-demo.js
@@ -61,4 +61,37 @@
   hero.setAttribute("data-motion-ready", "true");
   video.load();
   setEngaged(false);
+
+  var journey = document.getElementById("journey");
+  var steps = Array.prototype.slice.call(document.querySelectorAll(".infr-step"));
+  var progressPath = document.querySelector(".infr-packet-map__progress");
+  var mapNodes = Array.prototype.slice.call(document.querySelectorAll(".infr-map-node"));
+  var mapStatus = document.querySelector(".infr-packet-map__status");
+
+  function showJourneyStage(stage, text) {
+    var lastStage = Math.max(steps.length - 1, 1);
+    var progress = Math.min(Math.max(stage / lastStage, 0), 1);
+
+    steps.forEach(function (step) {
+      step.classList.toggle("is-active", Number(step.dataset.stage) === stage);
+    });
+    mapNodes.forEach(function (node) {
+      node.classList.toggle("is-active", Number(node.dataset.node) <= stage);
+    });
+    if (progressPath) progressPath.style.strokeDashoffset = String(1 - progress);
+    if (mapStatus && text) mapStatus.textContent = text;
+  }
+
+  if (journey && steps.length && "IntersectionObserver" in window) {
+    var stepObserver = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (!entry.isIntersecting) return;
+        showJourneyStage(Number(entry.target.dataset.stage), entry.target.dataset.status);
+      });
+    }, { rootMargin: "-38% 0px -42% 0px", threshold: 0 });
+
+    steps.forEach(function (step) { stepObserver.observe(step); });
+  }
+
+  showJourneyStage(0, steps[0] && steps[0].dataset.status);
 }());

--- a/assets/scripts/infr-webm-demo.js
+++ b/assets/scripts/infr-webm-demo.js
@@ -9,6 +9,8 @@
 
   var reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
   var svg = hero.querySelector(".infr-network-flow");
+  var controlLabel = control.querySelector(".infr-route-control__label");
+  var interactionLocked = false;
 
   function setStatus(mode, text) {
     if (!status || !statusText) return;
@@ -19,6 +21,9 @@
   function setEngaged(engaged) {
     hero.toggleAttribute("data-engaged", engaged);
     control.setAttribute("aria-pressed", String(engaged));
+    if (controlLabel) {
+      controlLabel.textContent = engaged && interactionLocked ? "關閉發亮訊號" : "讓訊號重新連上";
+    }
 
     if (reducedMotion.matches || !engaged) {
       video.pause();
@@ -48,15 +53,28 @@
   });
 
   control.addEventListener("pointerenter", function () { setEngaged(true); });
-  control.addEventListener("pointerleave", function () { setEngaged(false); });
+  control.addEventListener("pointerleave", function () {
+    if (!interactionLocked) setEngaged(false);
+  });
   control.addEventListener("focus", function () { setEngaged(true); });
-  control.addEventListener("blur", function () { setEngaged(false); });
-  control.addEventListener("click", function () { setEngaged(true); });
+  control.addEventListener("blur", function () {
+    if (!interactionLocked) setEngaged(false);
+  });
+  control.addEventListener("click", function () {
+    interactionLocked = !interactionLocked;
+    setEngaged(interactionLocked);
+  });
 
   if (typeof reducedMotion.addEventListener === "function") {
-    reducedMotion.addEventListener("change", function () { setEngaged(false); });
+    reducedMotion.addEventListener("change", function () {
+      interactionLocked = false;
+      setEngaged(false);
+    });
   } else if (typeof reducedMotion.addListener === "function") {
-    reducedMotion.addListener(function () { setEngaged(false); });
+    reducedMotion.addListener(function () {
+      interactionLocked = false;
+      setEngaged(false);
+    });
   }
   hero.setAttribute("data-motion-ready", "true");
   video.load();

--- a/assets/styles/infr-aval-demo.css
+++ b/assets/styles/infr-aval-demo.css
@@ -309,5 +309,5 @@ html { scroll-behavior: smooth; }
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
   .infr-route-control, .infr-hero__motion, .infr-network-flow, .infr-step, .infr-packet-map__progress { transition: none; }
-  .infr-network-flow { display: none; }
+  .infr-network-flow__routes use { animation: none; }
 }

--- a/assets/styles/infr-aval-demo.css
+++ b/assets/styles/infr-aval-demo.css
@@ -244,24 +244,24 @@ html { scroll-behavior: smooth; }
 
 /* The shared project theme colors every heading and link purple. Dark story
    sections need stronger, local selectors to preserve readable contrast. */
-#project .infr-hero h1,
-#project .infr-journey h2,
-#project .infr-journey h3,
-#project .infr-work h2,
-#project .infr-work h3,
-#project .infr-closing h2 { color: #fff; }
+:is(#project, #internet-freedom) .infr-hero h1,
+:is(#project, #internet-freedom) .infr-journey h2,
+:is(#project, #internet-freedom) .infr-journey h3,
+:is(#project, #internet-freedom) .infr-work h2,
+:is(#project, #internet-freedom) .infr-work h3,
+:is(#project, #internet-freedom) .infr-closing h2 { color: #fff; }
 
-#project .infr-section-nav a { color: rgba(255,255,255,.72); }
-#project .infr-section-nav a:hover,
-#project .infr-section-nav a:focus-visible,
-#project .infr-hero__link,
-#project .infr-text-link { color: #fff; }
-#project .infr-hero__link:hover,
-#project .infr-hero__link:focus-visible { color: var(--infr-amber); }
-#project .infr-work-grid a { color: var(--infr-purple-light); }
-#project .infr-button,
-#project .infr-button:hover,
-#project .infr-button:focus-visible { color: #fff; }
+:is(#project, #internet-freedom) .infr-section-nav a { color: rgba(255,255,255,.72); }
+:is(#project, #internet-freedom) .infr-section-nav a:hover,
+:is(#project, #internet-freedom) .infr-section-nav a:focus-visible,
+:is(#project, #internet-freedom) .infr-hero__link,
+:is(#project, #internet-freedom) .infr-text-link { color: #fff; }
+:is(#project, #internet-freedom) .infr-hero__link:hover,
+:is(#project, #internet-freedom) .infr-hero__link:focus-visible { color: var(--infr-amber); }
+:is(#project, #internet-freedom) .infr-work-grid a { color: var(--infr-purple-light); }
+:is(#project, #internet-freedom) .infr-button,
+:is(#project, #internet-freedom) .infr-button:hover,
+:is(#project, #internet-freedom) .infr-button:focus-visible { color: #fff; }
 
 @media (max-width: 900px) {
   .infr-opening__copy, .infr-topic-grid, .infr-work-grid, .infr-meetup { grid-template-columns: 1fr; }

--- a/assets/styles/infr-aval-demo.css
+++ b/assets/styles/infr-aval-demo.css
@@ -73,6 +73,7 @@ html { scroll-behavior: smooth; }
   pointer-events: none;
   opacity: 0;
   filter: saturate(.85) brightness(.8);
+  mix-blend-mode: screen;
   transition: filter .45s ease, opacity .45s ease;
 }
 
@@ -89,8 +90,9 @@ html { scroll-behavior: smooth; }
 .infr-network-flow__routes use:nth-child(2) { animation-duration: 3.6s; opacity: .78; }
 .infr-network-flow__routes use:nth-child(3) { animation-duration: 4.2s; opacity: .65; }
 .infr-network-flow__signals circle { fill: #fff4c7; stroke: #ff714e; stroke-width: 1.5; }
-.infr-hero[data-engaged] .infr-network-flow { opacity: 1; filter: saturate(1.3) brightness(1.35); }
-.infr-hero[data-engaged] .infr-network-flow__routes use { animation-duration: 1.35s; animation-play-state: running; }
+.infr-hero[data-engaged] .infr-network-flow { opacity: 1; filter: saturate(1.55) brightness(1.75) drop-shadow(0 0 14px rgba(255,118,78,.72)); }
+.infr-hero[data-engaged] .infr-network-flow__routes use { animation-duration: 1.35s; animation-play-state: running; stroke: rgba(255,216,148,.98); stroke-width: 2.6; }
+.infr-hero[data-engaged] .infr-network-flow__signals circle { fill: #fff; stroke-width: 2.4; filter: drop-shadow(0 0 9px #ff784f); }
 @keyframes infr-route-flow { to { stroke-dashoffset: -108; } }
 
 .infr-hero__veil {
@@ -135,6 +137,7 @@ html { scroll-behavior: smooth; }
 
 .infr-route-control:hover, .infr-route-control:focus-visible { border-color: var(--infr-amber); background: rgba(77,38,105,.88); outline: none; transform: translateY(-2px); }
 .infr-route-control__dot { width: 11px; height: 11px; border-radius: 50%; background: var(--infr-coral); box-shadow: 0 0 0 5px rgba(255,104,77,.17), 0 0 18px var(--infr-coral); }
+.infr-hero[data-engaged] .infr-route-control__dot { background: #fff2bb; box-shadow: 0 0 0 6px rgba(255,189,105,.24), 0 0 28px 7px rgba(255,104,77,.9); }
 .infr-hero__link { border-bottom: 1px solid rgba(255,255,255,.5); padding: 8px 0; color: #fff; font-weight: 700; }
 .infr-hero__link:hover, .infr-hero__link:focus-visible { border-color: var(--infr-amber); color: var(--infr-amber); }
 

--- a/assets/styles/infr-aval-demo.css
+++ b/assets/styles/infr-aval-demo.css
@@ -1,39 +1,60 @@
 :root {
   --infr-night: #080823;
-  --infr-purple: #7d56c9;
+  --infr-night-soft: #121032;
+  --infr-purple: #7651c6;
+  --infr-purple-light: #b89cf1;
   --infr-coral: #ff684d;
   --infr-amber: #ffbd69;
+  --infr-mint: #75dfbd;
   --infr-paper: #fffaf4;
+  --infr-ink: #211d30;
+  --infr-muted: #6d687a;
+  --infr-line: rgba(33, 29, 48, .14);
 }
 
-.infr-aval-demo {
+html { scroll-behavior: smooth; }
+
+.infr-story-page {
+  overflow: clip;
   background: var(--infr-paper);
-  color: #262236;
+  color: var(--infr-ink);
+  font-family: "Chiron Hei HK", "Noto Sans TC", sans-serif;
+}
+
+.infr-story-page * { box-sizing: border-box; }
+
+.infr-shell {
+  width: min(1180px, calc(100% - 48px));
+  margin-inline: auto;
+}
+
+.infr-kicker {
+  margin: 0 0 18px;
+  color: #7651b7;
+  font: 700 .8rem/1.4 "Roboto", sans-serif;
+  letter-spacing: .16em;
+  text-transform: uppercase;
 }
 
 .infr-hero {
   position: relative;
-  min-height: min(760px, calc(100vh - 72px));
+  min-height: min(800px, calc(100vh - 72px));
   overflow: hidden;
   isolation: isolate;
   background: var(--infr-night);
   color: #fff;
 }
 
-.infr-hero__motion,
-.infr-hero__fallback {
+.infr-hero__motion {
   position: absolute;
+  z-index: -3;
   inset: 0;
   display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;
-}
-
-.infr-hero__motion {
-  z-index: -3;
   transform: scale(1.001);
-  filter: saturate(.9) brightness(.7);
+  filter: saturate(.9) brightness(.68);
   transition: filter .6s ease, transform 1.2s ease;
 }
 
@@ -61,59 +82,28 @@
   stroke-width: 1.6;
   stroke-linecap: round;
   stroke-dasharray: 1.5 18;
-  animation: infr-route-flow 2.8s linear infinite;
-  animation-play-state: paused;
+  animation: infr-route-flow 2.8s linear infinite paused;
   filter: drop-shadow(0 0 4px rgba(255, 96, 64, .75));
 }
 
-.infr-network-flow__routes use:nth-child(2) {
-  animation-duration: 3.6s;
-  opacity: .78;
-}
-
-.infr-network-flow__routes use:nth-child(3) {
-  animation-duration: 4.2s;
-  opacity: .65;
-}
-
-.infr-network-flow__routes use:nth-child(4) {
-  animation-duration: 3.2s;
-  opacity: .55;
-}
-
-.infr-network-flow__signals circle {
-  fill: #fff4c7;
-  stroke: #ff714e;
-  stroke-width: 1.5;
-}
-
-.infr-hero[data-engaged] .infr-network-flow {
-  opacity: 1;
-  filter: saturate(1.3) brightness(1.35);
-}
-
-.infr-hero[data-engaged] .infr-network-flow__routes use {
-  animation-duration: 1.35s;
-  animation-play-state: running;
-}
-
-@keyframes infr-route-flow {
-  to { stroke-dashoffset: -108; }
-}
+.infr-network-flow__routes use:nth-child(2) { animation-duration: 3.6s; opacity: .78; }
+.infr-network-flow__routes use:nth-child(3) { animation-duration: 4.2s; opacity: .65; }
+.infr-network-flow__signals circle { fill: #fff4c7; stroke: #ff714e; stroke-width: 1.5; }
+.infr-hero[data-engaged] .infr-network-flow { opacity: 1; filter: saturate(1.3) brightness(1.35); }
+.infr-hero[data-engaged] .infr-network-flow__routes use { animation-duration: 1.35s; animation-play-state: running; }
+@keyframes infr-route-flow { to { stroke-dashoffset: -108; } }
 
 .infr-hero__veil {
   position: absolute;
   z-index: -2;
   inset: 0;
-  background:
-    linear-gradient(90deg, rgba(5, 7, 31, .98) 0%, rgba(5, 7, 31, .88) 31%, rgba(5, 7, 31, .28) 64%, rgba(5, 7, 31, .08) 100%),
-    linear-gradient(0deg, rgba(5, 7, 31, .55), transparent 45%);
+  background: linear-gradient(90deg, rgba(5, 7, 31, .98), rgba(5, 7, 31, .86) 32%, rgba(5, 7, 31, .2) 70%), linear-gradient(0deg, rgba(5, 7, 31, .58), transparent 45%);
   pointer-events: none;
 }
 
 .infr-hero__content {
   display: flex;
-  min-height: min(760px, calc(100vh - 72px));
+  min-height: min(800px, calc(100vh - 72px));
   flex-direction: column;
   align-items: flex-start;
   justify-content: center;
@@ -121,49 +111,21 @@
   padding-bottom: 72px;
 }
 
-.infr-hero__eyebrow,
-.infr-demo-note__label {
-  margin: 0 0 18px;
-  color: var(--infr-amber);
-  font: 700 .82rem/1.4 "Roboto", sans-serif;
-  letter-spacing: .15em;
-  text-transform: uppercase;
-}
-
-.infr-hero h1 {
-  max-width: 760px;
-  margin: 0;
-  font: 800 clamp(3rem, 6.3vw, 6.8rem)/.98 "Chiron Hei HK", "Noto Sans TC", sans-serif;
-  letter-spacing: -.055em;
-  text-wrap: balance;
-}
-
-.infr-hero__intro {
-  max-width: 610px;
-  margin: 32px 0 0;
-  color: rgba(255, 255, 255, .82);
-  font-size: clamp(1.05rem, 1.55vw, 1.25rem);
-  line-height: 1.8;
-}
-
-.infr-hero__actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 18px 26px;
-  margin-top: 36px;
-}
+.infr-hero__eyebrow { margin: 0 0 18px; color: var(--infr-amber); font: 700 .82rem/1.4 "Roboto", sans-serif; letter-spacing: .15em; text-transform: uppercase; }
+.infr-hero h1 { max-width: 760px; margin: 0; font: 800 clamp(3rem, 6.3vw, 6.8rem)/.98 "Chiron Hei HK", sans-serif; letter-spacing: -.055em; text-wrap: balance; }
+.infr-hero__intro { max-width: 610px; margin: 32px 0 0; color: rgba(255, 255, 255, .82); font-size: clamp(1.05rem, 1.55vw, 1.25rem); line-height: 1.8; }
+.infr-hero__actions { display: flex; flex-wrap: wrap; align-items: center; gap: 18px 26px; margin-top: 36px; }
 
 .infr-route-control {
   display: inline-flex;
   min-height: 52px;
   align-items: center;
   gap: 12px;
-  border: 1px solid rgba(255, 255, 255, .3);
+  border: 1px solid rgba(255,255,255,.3);
   border-radius: 999px;
   padding: 13px 22px;
-  background: rgba(15, 10, 45, .72);
-  box-shadow: 0 12px 32px rgba(3, 3, 20, .25);
+  background: rgba(15,10,45,.72);
+  box-shadow: 0 12px 32px rgba(3,3,20,.25);
   color: #fff;
   cursor: pointer;
   font: 700 1rem/1.25 inherit;
@@ -171,123 +133,178 @@
   transition: border-color .2s ease, background .2s ease, transform .2s ease;
 }
 
-.infr-route-control:hover,
-.infr-route-control:focus-visible {
-  border-color: var(--infr-amber);
-  background: rgba(77, 38, 105, .88);
-  outline: none;
-  transform: translateY(-2px);
-}
+.infr-route-control:hover, .infr-route-control:focus-visible { border-color: var(--infr-amber); background: rgba(77,38,105,.88); outline: none; transform: translateY(-2px); }
+.infr-route-control__dot { width: 11px; height: 11px; border-radius: 50%; background: var(--infr-coral); box-shadow: 0 0 0 5px rgba(255,104,77,.17), 0 0 18px var(--infr-coral); }
+.infr-hero__link { border-bottom: 1px solid rgba(255,255,255,.5); padding: 8px 0; color: #fff; font-weight: 700; }
+.infr-hero__link:hover, .infr-hero__link:focus-visible { border-color: var(--infr-amber); color: var(--infr-amber); }
 
-.infr-route-control__dot {
-  width: 11px;
-  height: 11px;
-  border-radius: 50%;
-  background: var(--infr-coral);
-  box-shadow: 0 0 0 5px rgba(255, 104, 77, .17), 0 0 18px var(--infr-coral);
-}
-
-.infr-hero__link {
-  border-bottom: 1px solid rgba(255, 255, 255, .5);
-  color: #fff;
-  font-weight: 700;
-  padding: 8px 0;
-}
-
-.infr-hero__link:hover,
-.infr-hero__link:focus-visible {
-  border-color: var(--infr-amber);
-  color: var(--infr-amber);
-}
-
-.infr-motion-status {
-  display: inline-flex;
+.infr-section-nav {
+  position: sticky;
+  z-index: 20;
+  top: 0;
+  display: flex;
+  min-height: 54px;
   align-items: center;
-  gap: 9px;
-  margin: 24px 0 0;
-  color: rgba(255, 255, 255, .58);
-  font-size: .82rem;
+  justify-content: center;
+  gap: clamp(18px, 4vw, 58px);
+  border-bottom: 1px solid rgba(255,255,255,.12);
+  background: rgba(8,8,35,.92);
+  backdrop-filter: blur(16px);
 }
 
-.infr-motion-status > span:first-child {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: #b8afc8;
-}
+.infr-section-nav a { padding: 17px 2px 14px; border-bottom: 2px solid transparent; color: rgba(255,255,255,.72); font-size: .9rem; font-weight: 700; }
+.infr-section-nav a:hover, .infr-section-nav a:focus-visible { border-color: var(--infr-amber); color: #fff; }
 
-.infr-motion-status[data-mode="motion"] > span:first-child {
-  background: #7ce2bc;
-  box-shadow: 0 0 10px rgba(124, 226, 188, .8);
-}
+.infr-opening { padding-block: clamp(100px, 13vw, 190px); }
+.infr-opening h2 { max-width: 940px; margin: 0; font-size: clamp(2.6rem, 6vw, 5.4rem); line-height: 1.08; letter-spacing: -.05em; }
+.infr-opening__copy { display: grid; grid-template-columns: 1fr 1fr; gap: 70px; max-width: 900px; margin: 72px 0 0 auto; }
+.infr-opening__copy p { margin: 0; color: #4c4758; font-size: 1.12rem; line-height: 1.95; }
 
-.infr-motion-status[data-mode="fallback"] > span:first-child {
-  background: var(--infr-amber);
-}
+.infr-journey { position: relative; display: grid; grid-template-columns: minmax(0, 1.1fr) minmax(380px, .9fr); background: var(--infr-night); color: #fff; }
+.infr-journey__visual { position: relative; min-height: 100vh; }
+.infr-packet-map { position: sticky; top: 54px; display: flex; height: calc(100vh - 54px); min-height: 620px; align-items: center; justify-content: center; overflow: hidden; background: radial-gradient(circle at 55% 45%, rgba(111,70,190,.26), transparent 38%), linear-gradient(145deg, #090a28, #131038); }
+.infr-packet-map::before { content: ""; position: absolute; inset: 0; opacity: .3; background-image: linear-gradient(rgba(255,255,255,.035) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.035) 1px, transparent 1px); background-size: 42px 42px; }
+.infr-packet-map svg { position: relative; width: min(86%, 760px); overflow: visible; }
+.infr-packet-map__label { position: absolute; top: 40px; left: 48px; color: var(--infr-amber); font: 700 .8rem/1.4 "Roboto", sans-serif; letter-spacing: .16em; text-transform: uppercase; }
+.infr-packet-map__path, .infr-packet-map__progress { fill: none; stroke-linecap: round; stroke-width: 3; }
+.infr-packet-map__path { stroke: rgba(255,255,255,.13); stroke-dasharray: 7 12; }
+.infr-packet-map__progress { stroke: var(--infr-coral); stroke-dasharray: 1; stroke-dashoffset: 1; filter: drop-shadow(0 0 10px rgba(255,104,77,.75)); transition: stroke-dashoffset .8s cubic-bezier(.2,.8,.2,1); }
+.infr-map-node circle { fill: #17143d; stroke: rgba(255,255,255,.35); stroke-width: 3; transition: fill .4s ease, stroke .4s ease, filter .4s ease; }
+.infr-map-node text { fill: rgba(255,255,255,.55); font-size: 16px; font-weight: 700; text-anchor: middle; transition: fill .4s ease; }
+.infr-map-node.is-active circle { fill: var(--infr-coral); stroke: #ffd09a; filter: drop-shadow(0 0 13px rgba(255,104,77,.9)); }
+.infr-map-node.is-active text { fill: #fff; }
+.infr-packet-map__status { position: absolute; right: 48px; bottom: 38px; left: 48px; margin: 0; color: rgba(255,255,255,.62); font-size: .9rem; text-align: center; }
+.infr-journey__steps { padding: 14vh clamp(32px, 6vw, 94px) 20vh; }
+.infr-journey__intro { min-height: 55vh; padding-top: 8vh; }
+.infr-journey__intro h2 { max-width: 590px; margin: 0; font-size: clamp(2.6rem, 4.8vw, 4.8rem); line-height: 1.08; letter-spacing: -.05em; }
+.infr-step { min-height: 74vh; max-width: 570px; padding: 50px 0; opacity: .28; transform: translateY(28px); transition: opacity .45s ease, transform .45s ease; }
+.infr-step.is-active { opacity: 1; transform: translateY(0); }
+.infr-step > span { display: block; margin-bottom: 22px; color: var(--infr-coral); font: 700 .85rem/1 "Roboto", sans-serif; }
+.infr-step h3 { margin: 0 0 24px; font-size: clamp(2rem, 3.3vw, 3.5rem); line-height: 1.16; }
+.infr-step p { margin: 0; color: rgba(255,255,255,.72); font-size: 1.12rem; line-height: 1.9; }
 
-.infr-demo-note {
-  max-width: 900px;
-  padding-top: 80px;
-  padding-bottom: 96px;
-}
+.infr-topics { padding-block: clamp(100px, 12vw, 170px); }
+.infr-section-heading { max-width: 780px; margin-bottom: 70px; }
+.infr-section-heading h2 { margin: 0 0 24px; font-size: clamp(2.6rem, 5vw, 4.8rem); line-height: 1.08; letter-spacing: -.045em; }
+.infr-section-heading > p:last-child { max-width: 680px; margin: 0; color: var(--infr-muted); font-size: 1.12rem; line-height: 1.85; }
+.infr-topic-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+.infr-topic-card { position: relative; min-height: 420px; overflow: hidden; border: 1px solid var(--infr-line); border-radius: 24px; padding: clamp(32px, 4vw, 54px); background: rgba(255,255,255,.62); }
+.infr-topic-card__number { color: #9b94a8; font: 700 .82rem/1 "Roboto", sans-serif; }
+.infr-topic-card__signal { width: 72px; height: 72px; margin: 56px 0 30px; border: 1px solid currentColor; border-radius: 50%; color: var(--infr-purple); box-shadow: inset 0 0 0 16px rgba(118,81,198,.08), 0 0 0 8px rgba(118,81,198,.04); }
+.infr-topic-card--privacy .infr-topic-card__signal { border-radius: 18px 18px 50% 50%; color: var(--infr-coral); }
+.infr-topic-card--platform .infr-topic-card__signal { border-radius: 8px; color: #de9450; transform: rotate(45deg); }
+.infr-topic-card--resilience .infr-topic-card__signal { border-style: dashed; color: #3a9e87; }
+.infr-topic-card h3 { margin: 0 0 18px; font-size: clamp(1.65rem, 3vw, 2.4rem); }
+.infr-topic-card p { max-width: 490px; margin: 0 0 30px; color: var(--infr-muted); font-size: 1.02rem; line-height: 1.82; }
+.infr-topic-card a { color: #6842a9; font-weight: 700; }
 
-.infr-demo-note__label {
-  color: #7750b6;
-}
+.infr-work { padding-block: clamp(100px, 12vw, 170px); background: #181636; color: #fff; }
+.infr-section-heading--light .infr-kicker { color: var(--infr-amber); }
+.infr-section-heading--light > p:last-child { color: rgba(255,255,255,.65); }
+.infr-work-grid { display: grid; grid-template-columns: repeat(2, 1fr); border-top: 1px solid rgba(255,255,255,.15); border-left: 1px solid rgba(255,255,255,.15); }
+.infr-work-grid article { min-height: 330px; border-right: 1px solid rgba(255,255,255,.15); border-bottom: 1px solid rgba(255,255,255,.15); padding: clamp(32px, 4vw, 52px); }
+.infr-work-grid strong { color: var(--infr-amber); font-size: .82rem; letter-spacing: .14em; }
+.infr-work-grid h3 { margin: 34px 0 18px; font-size: clamp(1.6rem, 3vw, 2.5rem); line-height: 1.25; }
+.infr-work-grid p { margin: 0 0 28px; color: rgba(255,255,255,.65); font-size: 1rem; line-height: 1.8; }
+.infr-work-grid a { color: var(--infr-purple-light); font-weight: 700; }
+.infr-history { display: grid; grid-template-columns: repeat(4, 1fr); margin-top: 110px; border-top: 1px solid rgba(255,255,255,.2); }
+.infr-history div { position: relative; padding: 34px 26px 0 0; }
+.infr-history div::before { content: ""; position: absolute; top: -6px; left: 0; width: 11px; height: 11px; border-radius: 50%; background: var(--infr-coral); box-shadow: 0 0 0 5px rgba(255,104,77,.13); }
+.infr-history time { color: var(--infr-amber); font: 700 1.1rem/1 "Roboto", sans-serif; }
+.infr-history p { color: rgba(255,255,255,.62); line-height: 1.75; }
 
-.infr-demo-note h2 {
-  margin: 0 0 22px;
-  color: #1b1730;
-  font-size: clamp(1.8rem, 4vw, 3.2rem);
-  line-height: 1.2;
-}
+.infr-meetup { display: grid; grid-template-columns: .85fr 1.15fr; gap: clamp(60px, 10vw, 150px); padding-block: clamp(100px, 13vw, 180px); }
+.infr-meetup__intro h2 { margin: 0 0 28px; font-size: clamp(2.6rem, 5vw, 4.8rem); line-height: 1.08; letter-spacing: -.045em; }
+.infr-meetup__intro > p:not(.infr-kicker) { margin: 0 0 36px; color: var(--infr-muted); font-size: 1.08rem; line-height: 1.85; }
+.infr-button { display: inline-flex; min-height: 52px; align-items: center; justify-content: center; border-radius: 999px; padding: 14px 26px; background: var(--infr-coral); color: #fff; font-weight: 800; }
+.infr-button:hover, .infr-button:focus-visible { background: #e94c34; color: #fff; transform: translateY(-2px); }
+.infr-button--dark { background: var(--infr-night-soft); }
+.infr-button--dark:hover, .infr-button--dark:focus-visible { background: #30265f; }
+.infr-meetup__year { margin: 0 0 20px; color: #817a8b; font-size: .82rem; font-weight: 800; letter-spacing: .12em; }
+.infr-meetup__topics ol { margin: 0; padding: 0; list-style: none; border-top: 1px solid var(--infr-line); }
+.infr-meetup__topics li { border-bottom: 1px solid var(--infr-line); }
+.infr-meetup__topics li a { display: grid; grid-template-columns: 38px 1fr; gap: 15px; align-items: baseline; padding: 22px 4px; color: var(--infr-ink); font-size: 1.06rem; font-weight: 700; line-height: 1.55; }
+.infr-meetup__topics li a:hover { color: #6842a9; }
+.infr-meetup__topics li span { color: var(--infr-coral); font: 700 .75rem/1 "Roboto", sans-serif; }
+.infr-resource-links { display: flex; flex-wrap: wrap; gap: 12px 24px; margin-top: 30px; }
+.infr-resource-links a { border-bottom: 1px solid #8e80a7; color: #684f8d; font-weight: 700; }
 
-.infr-demo-note p:last-child {
-  max-width: 760px;
-  font-size: 1.1rem;
-  line-height: 1.85;
+.infr-closing { position: relative; min-height: 680px; display: flex; align-items: center; overflow: hidden; background: var(--infr-night); color: #fff; }
+.infr-closing .infr-shell { position: relative; z-index: 1; }
+.infr-closing .infr-kicker { color: var(--infr-amber); }
+.infr-closing h2 { max-width: 900px; margin: 0 0 26px; font-size: clamp(2.8rem, 6vw, 5.8rem); line-height: 1.06; letter-spacing: -.05em; }
+.infr-closing p:not(.infr-kicker) { color: rgba(255,255,255,.66); font-size: 1.15rem; }
+.infr-closing__actions { display: flex; flex-wrap: wrap; align-items: center; gap: 28px; margin-top: 38px; }
+.infr-text-link { color: #fff; font-weight: 700; }
+.infr-closing__signal { position: absolute; top: 50%; right: -5vw; width: min(46vw, 700px); aspect-ratio: 1; border: 1px solid rgba(255,189,105,.18); border-radius: 50%; transform: translateY(-50%); }
+.infr-closing__signal::before, .infr-closing__signal::after { content: ""; position: absolute; border: 1px solid rgba(255,189,105,.14); border-radius: inherit; }
+.infr-closing__signal::before { inset: 15%; }
+.infr-closing__signal::after { inset: 32%; }
+.infr-closing__signal span { position: absolute; inset: 46%; border-radius: 50%; background: var(--infr-coral); box-shadow: 0 0 70px 30px rgba(255,104,77,.34); }
+
+/* The shared project theme colors every heading and link purple. Dark story
+   sections need stronger, local selectors to preserve readable contrast. */
+#project .infr-hero h1,
+#project .infr-journey h2,
+#project .infr-journey h3,
+#project .infr-work h2,
+#project .infr-work h3,
+#project .infr-closing h2 { color: #fff; }
+
+#project .infr-section-nav a { color: rgba(255,255,255,.72); }
+#project .infr-section-nav a:hover,
+#project .infr-section-nav a:focus-visible,
+#project .infr-hero__link,
+#project .infr-text-link { color: #fff; }
+#project .infr-hero__link:hover,
+#project .infr-hero__link:focus-visible { color: var(--infr-amber); }
+#project .infr-work-grid a { color: var(--infr-purple-light); }
+#project .infr-button,
+#project .infr-button:hover,
+#project .infr-button:focus-visible { color: #fff; }
+
+@media (max-width: 900px) {
+  .infr-opening__copy, .infr-topic-grid, .infr-work-grid, .infr-meetup { grid-template-columns: 1fr; }
+  .infr-journey { grid-template-columns: minmax(0, .95fr) minmax(330px, 1.05fr); }
+  .infr-history { grid-template-columns: repeat(2, 1fr); row-gap: 50px; }
+  .infr-meetup { gap: 70px; }
 }
 
 @media (max-width: 720px) {
-  .infr-hero {
-    min-height: 720px;
-  }
-
-  .infr-hero__veil {
-    background:
-      linear-gradient(0deg, rgba(5, 7, 31, .98) 0%, rgba(5, 7, 31, .84) 52%, rgba(5, 7, 31, .25) 100%);
-  }
-
-  .infr-hero__content {
-    min-height: 720px;
-    justify-content: flex-end;
-    padding-top: 180px;
-    padding-bottom: 44px;
-  }
-
-  .infr-hero h1 {
-    font-size: clamp(2.75rem, 13vw, 4.5rem);
-  }
-
-  .infr-hero__intro {
-    margin-top: 24px;
-    font-size: 1rem;
-    line-height: 1.7;
-  }
-
-  .infr-motion-status {
-    margin-top: 18px;
-  }
+  .infr-shell { width: min(100% - 32px, 1180px); }
+  .infr-hero { min-height: 720px; }
+  .infr-hero__veil { background: linear-gradient(0deg, rgba(5,7,31,.98), rgba(5,7,31,.84) 55%, rgba(5,7,31,.25)); }
+  .infr-hero__content { min-height: 720px; justify-content: flex-end; padding: 180px 20px 48px; }
+  .infr-hero h1 { font-size: clamp(2.75rem, 13vw, 4.5rem); }
+  .infr-hero__intro { margin-top: 24px; font-size: 1rem; line-height: 1.7; }
+  .infr-section-nav { justify-content: flex-start; gap: 24px; overflow-x: auto; padding-inline: 18px; white-space: nowrap; }
+  .infr-opening { padding-block: 90px; }
+  .infr-opening h2, .infr-section-heading h2, .infr-meetup__intro h2 { font-size: 2.7rem; }
+  .infr-opening__copy { gap: 28px; margin-top: 50px; }
+  .infr-journey { display: block; padding: 80px 16px; }
+  .infr-journey__visual { min-height: auto; }
+  .infr-packet-map { position: relative; top: auto; height: auto; min-height: 410px; border-radius: 22px; }
+  .infr-packet-map__label { top: 24px; left: 24px; }
+  .infr-packet-map__status { right: 24px; bottom: 22px; left: 24px; }
+  .infr-journey__steps { padding: 70px 8px 0; }
+  .infr-journey__intro { min-height: auto; padding: 0 0 70px; }
+  .infr-journey__intro h2 { font-size: 2.7rem; }
+  .infr-step { min-height: auto; margin-bottom: 26px; border: 1px solid rgba(255,255,255,.13); border-radius: 18px; padding: 30px; opacity: 1; transform: none; }
+  .infr-step h3 { font-size: 1.8rem; }
+  .infr-topics, .infr-work, .infr-meetup { padding-block: 90px; }
+  .infr-topic-card { min-height: auto; }
+  .infr-topic-card__signal { margin-top: 42px; }
+  .infr-work-grid { border-left: 0; }
+  .infr-work-grid article { min-height: auto; border-left: 1px solid rgba(255,255,255,.15); }
+  .infr-history { grid-template-columns: 1fr; margin-top: 80px; }
+  .infr-meetup { gap: 60px; }
+  .infr-closing { min-height: 650px; }
+  .infr-closing h2 { font-size: 3rem; }
+  .infr-closing__signal { right: -50%; width: 120vw; opacity: .6; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .infr-route-control,
-  .infr-hero__motion,
-  .infr-network-flow {
-    transition: none;
-  }
-
-  .infr-network-flow {
-    display: none;
-  }
+  html { scroll-behavior: auto; }
+  .infr-route-control, .infr-hero__motion, .infr-network-flow, .infr-step, .infr-packet-map__progress { transition: none; }
+  .infr-network-flow { display: none; }
 }

--- a/internet-freedom/index.html
+++ b/internet-freedom/index.html
@@ -5,8 +5,8 @@ og_title: 網路自由
 og_description: 從一次連線開始，理解網路封鎖、隱私監控、平台權力與網路韌性，以及 OCF 如何讓網路保持開放。
 og_image: /p/infr/assets/internet-freedom-poster.jpg
 
-css: infr-aval-demo.css?v=8
-js: infr-webm-demo.js?v=8
+css: infr-aval-demo.css?v=9
+js: infr-webm-demo.js?v=9
 ---
 <nav class="infr-section-nav" aria-label="本頁段落">
   <a href="#journey">連線的旅程</a>

--- a/internet-freedom/index.html
+++ b/internet-freedom/index.html
@@ -1,0 +1,152 @@
+---
+layout: internet-freedom
+
+og_title: 網路自由
+og_description: 從一次連線開始，理解網路封鎖、隱私監控、平台權力與網路韌性，以及 OCF 如何讓網路保持開放。
+og_image: /p/infr/assets/internet-freedom-poster.jpg
+
+css: infr-aval-demo.css?v=8
+js: infr-webm-demo.js?v=8
+---
+<nav class="infr-section-nav" aria-label="本頁段落">
+  <a href="#journey">連線的旅程</a>
+  <a href="#topics">認識問題</a>
+  <a href="#work">OCF 的工作</a>
+  <a href="#meetup">近期行動</a>
+</nav>
+
+<section class="infr-opening infr-shell" aria-labelledby="infr-opening-title">
+  <p class="infr-kicker">從一次連線開始</p>
+  <h2 id="infr-opening-title">你看到網頁的這一刻，<br>資料已經經過許多人的手。</h2>
+  <div class="infr-opening__copy">
+    <p>你輸入網址，裝置先詢問網站在哪裡，再向伺服器索取內容。這段短短幾秒的路程，經過電信網路、DNS、平台與跨國海纜。每一站都可能影響你能不能抵達，也可能留下紀錄。</p>
+    <p>網路自由關注人們能否使用網路取得資訊、表達意見與組織行動，同時免於不當監控、審查與差別待遇。</p>
+  </div>
+</section>
+
+<section id="journey" class="infr-journey" aria-labelledby="infr-journey-title">
+  <div class="infr-journey__visual" aria-hidden="true">
+    <div class="infr-packet-map">
+      <div class="infr-packet-map__label">一次連線</div>
+      <svg viewBox="0 0 720 540" role="presentation">
+        <path class="infr-packet-map__path" d="M80 420 C155 420 153 306 244 306 S332 202 425 202 S525 112 642 112"></path>
+        <path class="infr-packet-map__progress" d="M80 420 C155 420 153 306 244 306 S332 202 425 202 S525 112 642 112"></path>
+        <g class="infr-map-node" data-node="0" transform="translate(80 420)"><circle r="15"></circle><text y="43">你的裝置</text></g>
+        <g class="infr-map-node" data-node="1" transform="translate(244 306)"><circle r="15"></circle><text y="43">DNS</text></g>
+        <g class="infr-map-node" data-node="2" transform="translate(425 202)"><circle r="15"></circle><text y="43">網路與平台</text></g>
+        <g class="infr-map-node" data-node="3" transform="translate(642 112)"><circle r="15"></circle><text y="43">目的地</text></g>
+      </svg>
+      <p class="infr-packet-map__status">輸入網址，準備送出請求</p>
+    </div>
+  </div>
+  <div class="infr-journey__steps">
+    <header class="infr-journey__intro">
+      <p class="infr-kicker">一則訊息如何抵達</p>
+      <h2 id="infr-journey-title">連得上，是許多條件暫時都成立。</h2>
+    </header>
+    <article class="infr-step is-active" data-stage="0" data-status="輸入網址，準備送出請求">
+      <span>01</span><h3>你發出請求</h3>
+      <p>瀏覽器需要知道網站所在的 IP 位址。這個查詢通常會交給 DNS 服務處理。</p>
+    </article>
+    <article class="infr-step" data-stage="1" data-status="DNS 正在回答網站位址">
+      <span>02</span><h3>有人替網路指路</h3>
+      <p>DNS 像網路的地址簿。錯誤回覆、攔截查詢或修改紀錄，都可能讓使用者找不到原本的網站。</p>
+    </article>
+    <article class="infr-step" data-stage="2" data-status="請求通過網路與平台規則">
+      <span>03</span><h3>沿途可以觀察，也能阻擋</h3>
+      <p>電信業者、平台與政府各自掌握不同的技術和權力。限速、封鎖、內容下架與流量監控，可能發生在不同位置。</p>
+    </article>
+    <article class="infr-step" data-stage="3" data-status="訊息抵達，但自由仍需要被守住">
+      <span>04</span><h3>抵達不代表問題消失</h3>
+      <p>連線成功之後，個資如何被蒐集、演算法如何決定內容能見度、使用者能否申訴，仍會影響每個人的數位權利。</p>
+    </article>
+  </div>
+</section>
+
+<section id="topics" class="infr-topics infr-shell" aria-labelledby="infr-topics-title">
+  <div class="infr-section-heading">
+    <p class="infr-kicker">問題離生活很近</p>
+    <h2 id="infr-topics-title">網路自由受到哪些壓力？</h2>
+    <p>封鎖只是其中一種形式。日常使用的服務、裝置與制度，都會改變人們在網路上的處境。</p>
+  </div>
+  <div class="infr-topic-grid">
+    <article class="infr-topic-card infr-topic-card--censorship">
+      <span class="infr-topic-card__number">01</span><div class="infr-topic-card__signal" aria-hidden="true"></div>
+      <h3>網路封鎖與審查</h3><p>網站突然無法開啟，可能來自 DNS、IP、關鍵字或整段網路的封鎖。測量工具能協助我們分辨技術故障與人為干預。</p>
+      <a href="/p/ooni/">認識 OONI <span aria-hidden="true">→</span></a>
+    </article>
+    <article class="infr-topic-card infr-topic-card--privacy">
+      <span class="infr-topic-card__number">02</span><div class="infr-topic-card__signal" aria-hidden="true"></div>
+      <h3>隱私與監控</h3><p>瀏覽紀錄、位置、聯絡人與生物特徵都能拼出一個人的生活。資料蒐集需要清楚界線，也需要真正可行的拒絕方式。</p>
+      <a href="/p/eid/">閱讀數位身分案例 <span aria-hidden="true">→</span></a>
+    </article>
+    <article class="infr-topic-card infr-topic-card--platform">
+      <span class="infr-topic-card__number">03</span><div class="infr-topic-card__signal" aria-hidden="true"></div>
+      <h3>平台權力</h3><p>內容排序、下架與帳號停權會改變公共討論。規則需要透明，受到錯誤處置的人也需要有效的申訴管道。</p>
+      <a href="/p/issues/">查看議題倡議 <span aria-hidden="true">→</span></a>
+    </article>
+    <article class="infr-topic-card infr-topic-card--resilience">
+      <span class="infr-topic-card__number">04</span><div class="infr-topic-card__signal" aria-hidden="true"></div>
+      <h3>網路韌性</h3><p>海纜、基地台與資料中心都可能中斷。災害或政治危機發生時，通訊備援與開放工具會直接影響人們能否互相找到。</p>
+      <a href="#meetup">查看相關小聚 <span aria-hidden="true">→</span></a>
+    </article>
+  </div>
+</section>
+
+<section id="work" class="infr-work" aria-labelledby="infr-work-title">
+  <div class="infr-shell">
+    <div class="infr-section-heading infr-section-heading--light">
+      <p class="infr-kicker">把關心變成行動</p>
+      <h2 id="infr-work-title">OCF 如何守住網路自由</h2>
+      <p>技術問題需要測量，政策爭議需要追蹤，使用工具的人也需要互相交換經驗。我們讓這些工作在台灣持續發生。</p>
+    </div>
+    <div class="infr-work-grid">
+      <article><strong>測量</strong><h3>留下網路審查的證據</h3><p>推廣 OONI，協助更多人理解測量資料，辨認網站封鎖與連線異常。</p><a href="/p/ooni/">查看 OONI 專案</a></article>
+      <article><strong>討論</strong><h3>讓艱難議題有人能問</h3><p>網路自由小聚從 2019 年開始，持續討論隱私、平台治理、AI、通訊安全與網路韌性。</p><a href="#meetup">查看近期主題</a></article>
+      <article><strong>倡議</strong><h3>把公民觀點帶進政策現場</h3><p>追蹤數位治理與人權爭議，透過文章、聲明、會議參與及跨組織合作提出意見。</p><a href="/p/issues/">閱讀倡議工作</a></article>
+      <article><strong>串連</strong><h3>讓台灣加入國際對話</h3><p>參與 RightsCon、DRAPAC、IETF 與 OONI 社群，把在地經驗帶出去，也把國際方法帶回來。</p><a href="/p/global/">查看國際交流</a></article>
+    </div>
+    <div class="infr-history" aria-label="網路自由工作時間軸">
+      <div><time>2019</time><p>台北網路自由小聚開始，每月聚集關心數位權利的人。</p></div>
+      <div><time>2023</time><p>從 OONI、AI 到數位韌性，議題跨進更多生活與政策現場。</p></div>
+      <div><time>2025</time><p>RightsCon 在台北舉行，台灣公民社會與全球數位人權社群相遇。</p></div>
+      <div><time>2026</time><p>持續追問海纜、平台管制、災防通訊與身分資料帶來的新問題。</p></div>
+    </div>
+  </div>
+</section>
+
+{% assign current_event = site.data.p.infr.events | first %}
+<section id="meetup" class="infr-meetup infr-shell" aria-labelledby="infr-meetup-title">
+  <div class="infr-meetup__intro">
+    <p class="infr-kicker">Coffee &amp; Circumvention</p>
+    <h2 id="infr-meetup-title">下一個問題，帶來小聚一起拆。</h2>
+    <p>每個月第三個星期四，我們邀請技術工作者、研究者、記者、學生與一般使用者，從具體事件理解網路自由。</p>
+    <a class="infr-button infr-button--dark" href="https://ocftw.kktix.cc/" target="_blank" rel="noopener">查看最新活動</a>
+  </div>
+  <div class="infr-meetup__topics">
+    <p class="infr-meetup__year">2026 討論主題</p>
+    <ol>
+      {% for link in current_event.links %}
+      <li><a href="{{ link.url }}" target="_blank" rel="noopener"><span>{{ forloop.index | prepend: '0' }}</span>{{ link.title }}</a></li>
+      {% endfor %}
+    </ol>
+    <div class="infr-resource-links">
+      <a href="https://hackmd.io/efBMZl4ITImkxUOjlmByHg?view" target="_blank" rel="noopener">歷次活動共筆</a>
+      <a href="https://groups.google.com/g/coffee-circumvention-tw" target="_blank" rel="noopener">加入線上論壇</a>
+      <a href="https://www.youtube.com/watch?v=ek2XjW7Q3wI&amp;list=PLFuYOsppHDrlYquISvSfOjrT5g_mjMGot" target="_blank" rel="noopener">觀看活動影片</a>
+    </div>
+  </div>
+</section>
+
+<section class="infr-closing" aria-labelledby="infr-closing-title">
+  <div class="infr-closing__signal" aria-hidden="true"><span></span></div>
+  <div class="infr-shell">
+    <p class="infr-kicker">Keep the internet open</p>
+    <h2 id="infr-closing-title">自由的網路，需要有人持續測量、追問與行動。</h2>
+    <p>讓下一次連線，也能抵達它原本要去的地方。</p>
+    <div class="infr-closing__actions">
+      <a class="infr-button" href="https://ocf.tw/300/" target="_blank" rel="noopener">捐款支持 OCF</a>
+      <a class="infr-text-link" href="https://ocftw.kktix.cc/" target="_blank" rel="noopener">參加網路自由小聚 <span aria-hidden="true">→</span></a>
+    </div>
+  </div>
+</section>

--- a/p/infr/index.html
+++ b/p/infr/index.html
@@ -5,14 +5,10 @@ og_title: 網路自由
 og_description: 透過推廣、倡議等方式，訴求網路應以開放科技為基礎，力求言論自由、不受監控審查、技術保持中立。
 og_image: /p/infr/assets/internet-freedom-poster.jpg
 
-custom_header: infr-webm
-css: infr-aval-demo.css?v=8
-js: infr-webm-demo.js?v=8
-
 header_image_opacity: 0.75
 header_veil_opacity: 0.25
 
-show_events: no
+show_events: yes
 gsheet_url:
 show_sponsors: yes
 show_donors:
@@ -28,145 +24,15 @@ updated:
 cpid:
 show_child_projects: yes
 ---
-<nav class="infr-section-nav" aria-label="本頁段落">
-  <a href="#journey">連線的旅程</a>
-  <a href="#topics">認識問題</a>
-  <a href="#work">OCF 的工作</a>
-  <a href="#meetup">近期行動</a>
-</nav>
 
-<section class="infr-opening infr-shell" aria-labelledby="infr-opening-title">
-  <p class="infr-kicker">從一次連線開始</p>
-  <h2 id="infr-opening-title">你看到網頁的這一刻，<br>資料已經經過許多人的手。</h2>
-  <div class="infr-opening__copy">
-    <p>你輸入網址，裝置先詢問網站在哪裡，再向伺服器索取內容。這段短短幾秒的路程，經過電信網路、DNS、平台與跨國海纜。每一站都可能影響你能不能抵達，也可能留下紀錄。</p>
-    <p>網路自由關注人們能否使用網路取得資訊、表達意見與組織行動，同時免於不當監控、審查與差別待遇。</p>
-  </div>
-</section>
+<h2 class="ui dividing header">追尋真正的網路言論自由，就從關心周遭議題開始。</h2>
+<p>網路自由已經是國際各個組織越來越關心的議題，隨著世界各地威權國家或政治家，不斷透過監控設備、間諜軟體、不實資訊企圖混淆民眾的網路各項資訊來源，且我們的個人隱私資料，可能正從政府機關、電商平台外流出去，並透過網路不斷地傳送到世界各地。網路設備的安全、電信業者的中立性、平台的資料管理責任、政府相關單位的法制政策，都是現在很重要的網路自由相關議題。</p>
+<p>我們透過推廣、倡議等方式，訴求網路應以開放科技為基礎，力求言論自由、不受監控審查、技術保持中立。</p>
+<p>如果你也一樣關心網路自由，歡迎加入我們的網路論壇和每月小聚活動。</p>
 
-<section id="journey" class="infr-journey" aria-labelledby="infr-journey-title">
-  <div class="infr-journey__visual" aria-hidden="true">
-    <div class="infr-packet-map">
-      <div class="infr-packet-map__label">一次連線</div>
-      <svg viewBox="0 0 720 540" role="presentation">
-        <path class="infr-packet-map__path" d="M80 420 C155 420 153 306 244 306 S332 202 425 202 S525 112 642 112"></path>
-        <path class="infr-packet-map__progress" d="M80 420 C155 420 153 306 244 306 S332 202 425 202 S525 112 642 112"></path>
-        <g class="infr-map-node" data-node="0" transform="translate(80 420)"><circle r="15"></circle><text y="43">你的裝置</text></g>
-        <g class="infr-map-node" data-node="1" transform="translate(244 306)"><circle r="15"></circle><text y="43">DNS</text></g>
-        <g class="infr-map-node" data-node="2" transform="translate(425 202)"><circle r="15"></circle><text y="43">網路與平台</text></g>
-        <g class="infr-map-node" data-node="3" transform="translate(642 112)"><circle r="15"></circle><text y="43">目的地</text></g>
-      </svg>
-      <p class="infr-packet-map__status">輸入網址，準備送出請求</p>
-    </div>
-  </div>
-  <div class="infr-journey__steps">
-    <header class="infr-journey__intro">
-      <p class="infr-kicker">一則訊息如何抵達</p>
-      <h2 id="infr-journey-title">連得上，是許多條件暫時都成立。</h2>
-    </header>
-    <article class="infr-step is-active" data-stage="0" data-status="輸入網址，準備送出請求">
-      <span>01</span><h3>你發出請求</h3>
-      <p>瀏覽器需要知道網站所在的 IP 位址。這個查詢通常會交給 DNS 服務處理。</p>
-    </article>
-    <article class="infr-step" data-stage="1" data-status="DNS 正在回答網站位址">
-      <span>02</span><h3>有人替網路指路</h3>
-      <p>DNS 像網路的地址簿。錯誤回覆、攔截查詢或修改紀錄，都可能讓使用者找不到原本的網站。</p>
-    </article>
-    <article class="infr-step" data-stage="2" data-status="請求通過網路與平台規則">
-      <span>03</span><h3>沿途可以觀察，也能阻擋</h3>
-      <p>電信業者、平台與政府各自掌握不同的技術和權力。限速、封鎖、內容下架與流量監控，可能發生在不同位置。</p>
-    </article>
-    <article class="infr-step" data-stage="3" data-status="訊息抵達，但自由仍需要被守住">
-      <span>04</span><h3>抵達不代表問題消失</h3>
-      <p>連線成功之後，個資如何被蒐集、演算法如何決定內容能見度、使用者能否申訴，仍會影響每個人的數位權利。</p>
-    </article>
-  </div>
-</section>
-
-<section id="topics" class="infr-topics infr-shell" aria-labelledby="infr-topics-title">
-  <div class="infr-section-heading">
-    <p class="infr-kicker">問題離生活很近</p>
-    <h2 id="infr-topics-title">網路自由受到哪些壓力？</h2>
-    <p>封鎖只是其中一種形式。日常使用的服務、裝置與制度，都會改變人們在網路上的處境。</p>
-  </div>
-  <div class="infr-topic-grid">
-    <article class="infr-topic-card infr-topic-card--censorship">
-      <span class="infr-topic-card__number">01</span><div class="infr-topic-card__signal" aria-hidden="true"></div>
-      <h3>網路封鎖與審查</h3><p>網站突然無法開啟，可能來自 DNS、IP、關鍵字或整段網路的封鎖。測量工具能協助我們分辨技術故障與人為干預。</p>
-      <a href="/p/ooni/">認識 OONI <span aria-hidden="true">→</span></a>
-    </article>
-    <article class="infr-topic-card infr-topic-card--privacy">
-      <span class="infr-topic-card__number">02</span><div class="infr-topic-card__signal" aria-hidden="true"></div>
-      <h3>隱私與監控</h3><p>瀏覽紀錄、位置、聯絡人與生物特徵都能拼出一個人的生活。資料蒐集需要清楚界線，也需要真正可行的拒絕方式。</p>
-      <a href="/p/eid/">閱讀數位身分案例 <span aria-hidden="true">→</span></a>
-    </article>
-    <article class="infr-topic-card infr-topic-card--platform">
-      <span class="infr-topic-card__number">03</span><div class="infr-topic-card__signal" aria-hidden="true"></div>
-      <h3>平台權力</h3><p>內容排序、下架與帳號停權會改變公共討論。規則需要透明，受到錯誤處置的人也需要有效的申訴管道。</p>
-      <a href="/p/issues/">查看議題倡議 <span aria-hidden="true">→</span></a>
-    </article>
-    <article class="infr-topic-card infr-topic-card--resilience">
-      <span class="infr-topic-card__number">04</span><div class="infr-topic-card__signal" aria-hidden="true"></div>
-      <h3>網路韌性</h3><p>海纜、基地台與資料中心都可能中斷。災害或政治危機發生時，通訊備援與開放工具會直接影響人們能否互相找到。</p>
-      <a href="#meetup">查看相關小聚 <span aria-hidden="true">→</span></a>
-    </article>
-  </div>
-</section>
-
-<section id="work" class="infr-work" aria-labelledby="infr-work-title">
-  <div class="infr-shell">
-    <div class="infr-section-heading infr-section-heading--light">
-      <p class="infr-kicker">把關心變成行動</p>
-      <h2 id="infr-work-title">OCF 如何守住網路自由</h2>
-      <p>技術問題需要測量，政策爭議需要追蹤，使用工具的人也需要互相交換經驗。我們讓這些工作在台灣持續發生。</p>
-    </div>
-    <div class="infr-work-grid">
-      <article><strong>測量</strong><h3>留下網路審查的證據</h3><p>推廣 OONI，協助更多人理解測量資料，辨認網站封鎖與連線異常。</p><a href="/p/ooni/">查看 OONI 專案</a></article>
-      <article><strong>討論</strong><h3>讓艱難議題有人能問</h3><p>網路自由小聚從 2019 年開始，持續討論隱私、平台治理、AI、通訊安全與網路韌性。</p><a href="#meetup">查看近期主題</a></article>
-      <article><strong>倡議</strong><h3>把公民觀點帶進政策現場</h3><p>追蹤數位治理與人權爭議，透過文章、聲明、會議參與及跨組織合作提出意見。</p><a href="/p/issues/">閱讀倡議工作</a></article>
-      <article><strong>串連</strong><h3>讓台灣加入國際對話</h3><p>參與 RightsCon、DRAPAC、IETF 與 OONI 社群，把在地經驗帶出去，也把國際方法帶回來。</p><a href="/p/global/">查看國際交流</a></article>
-    </div>
-    <div class="infr-history" aria-label="網路自由工作時間軸">
-      <div><time>2019</time><p>台北網路自由小聚開始，每月聚集關心數位權利的人。</p></div>
-      <div><time>2023</time><p>從 OONI、AI 到數位韌性，議題跨進更多生活與政策現場。</p></div>
-      <div><time>2025</time><p>RightsCon 在台北舉行，台灣公民社會與全球數位人權社群相遇。</p></div>
-      <div><time>2026</time><p>持續追問海纜、平台管制、災防通訊與身分資料帶來的新問題。</p></div>
-    </div>
-  </div>
-</section>
-
-{% assign current_event = site.data.p.infr.events | first %}
-<section id="meetup" class="infr-meetup infr-shell" aria-labelledby="infr-meetup-title">
-  <div class="infr-meetup__intro">
-    <p class="infr-kicker">Coffee &amp; Circumvention</p>
-    <h2 id="infr-meetup-title">下一個問題，帶來小聚一起拆。</h2>
-    <p>每個月第三個星期四，我們邀請技術工作者、研究者、記者、學生與一般使用者，從具體事件理解網路自由。</p>
-    <a class="infr-button infr-button--dark" href="https://ocftw.kktix.cc/" target="_blank" rel="noopener">查看最新活動</a>
-  </div>
-  <div class="infr-meetup__topics">
-    <p class="infr-meetup__year">2026 討論主題</p>
-    <ol>
-      {% for link in current_event.links %}
-      <li><a href="{{ link.url }}" target="_blank" rel="noopener"><span>{{ forloop.index | prepend: '0' }}</span>{{ link.title }}</a></li>
-      {% endfor %}
-    </ol>
-    <div class="infr-resource-links">
-      <a href="https://hackmd.io/efBMZl4ITImkxUOjlmByHg?view" target="_blank" rel="noopener">歷次活動共筆</a>
-      <a href="https://groups.google.com/g/coffee-circumvention-tw" target="_blank" rel="noopener">加入線上論壇</a>
-      <a href="https://www.youtube.com/watch?v=ek2XjW7Q3wI&amp;list=PLFuYOsppHDrlYquISvSfOjrT5g_mjMGot" target="_blank" rel="noopener">觀看活動影片</a>
-    </div>
-  </div>
-</section>
-
-<section class="infr-closing" aria-labelledby="infr-closing-title">
-  <div class="infr-closing__signal" aria-hidden="true"><span></span></div>
-  <div class="infr-shell">
-    <p class="infr-kicker">Keep the internet open</p>
-    <h2 id="infr-closing-title">自由的網路，需要有人持續測量、追問與行動。</h2>
-    <p>讓下一次連線，也能抵達它原本要去的地方。</p>
-    <div class="infr-closing__actions">
-      <a class="infr-button" href="https://ocf.tw/300/" target="_blank" rel="noopener">捐款支持 OCF</a>
-      <a class="infr-text-link" href="https://ocftw.kktix.cc/" target="_blank" rel="noopener">參加網路自由小聚 <span aria-hidden="true">→</span></a>
-    </div>
-  </div>
-</section>
+<p><a href="/internet-freedom/"><i class="globe icon"></i>閱讀網路自由議題說明</a></p>
+<p><a href="https://groups.google.com/g/coffee-circumvention-tw" target="_blank"><i class="globe icon"></i>網路自由小聚線上論壇</a></p>
+<p><a href="https://ocftw.kktix.cc/" target="_blank"><i class="globe icon"></i>網路自由小聚活動</a></p>
+<p><a href="https://hackmd.io/efBMZl4ITImkxUOjlmByHg?view" target="_blank"><i class="globe icon"></i>網路自由小聚活動共筆</a></p>
+<p><a href="https://youtu.be/04fsSK3q7Oo?si=iNItWnSuPDtELc-J" target="_blank"><i class="globe icon"></i>網路自由小劇場 Podcast</a></p>
+<p><a href="https://www.youtube.com/watch?v=ek2XjW7Q3wI&amp;list=PLFuYOsppHDrlYquISvSfOjrT5g_mjMGot" target="_blank"><i class="globe icon"></i>網路自由小聚 2024 Recap</a></p>

--- a/p/infr/index.html
+++ b/p/infr/index.html
@@ -6,13 +6,13 @@ og_description: 透過推廣、倡議等方式，訴求網路應以開放科技�
 og_image: /p/infr/assets/internet-freedom-poster.jpg
 
 custom_header: infr-webm
-css: infr-aval-demo.css?v=6
-js: infr-webm-demo.js?v=7
+css: infr-aval-demo.css?v=8
+js: infr-webm-demo.js?v=8
 
 header_image_opacity: 0.75
 header_veil_opacity: 0.25
 
-show_events: yes
+show_events: no
 gsheet_url:
 show_sponsors: yes
 show_donors:
@@ -28,47 +28,145 @@ updated:
 cpid:
 show_child_projects: yes
 ---
-<h2 class="ui dividing header">追尋真正的網路言論自由，就從關心周遭議題開始。</h2>
-<p>網路自由已經是國際各個組織越來越關心的議題，隨著世界各地威權國家或政治家，不斷透過監控設備、間諜軟體、不實資訊企圖混淆民眾的網路各項資訊來源，且我們的個人隱私資料，可能正從政府機關、電商平台外流出去，並透過網路不斷地傳送到世界各地。網路設備的安全、電信業者的中立性、平台的資料管理責任、政府相關單位的法制政策，都是現在很重要的網路自由相關議題。</p>
-<p>我們透過推廣、倡議等方式，訴求網路應以開放科技為基礎，力求言論自由、不受監控審查、技術保持中立。</p>
-<p>如果你也一樣關心網路自由，歡迎加入我們的網路論壇和每月小聚活動。</p>
-<div class="ui list">
-    <div class="item">
-        <i class="checkmark icon"></i>
-        <div class="content">
-            網路自由小聚，國際夥伴發起，有興趣的社群朋友一同主辦，每月固定第三個禮拜四，討論交流網路自由相關議題，議題包羅萬象，也包含了資安隱私、數位人權...等。
-        </div>
+<nav class="infr-section-nav" aria-label="本頁段落">
+  <a href="#journey">連線的旅程</a>
+  <a href="#topics">認識問題</a>
+  <a href="#work">OCF 的工作</a>
+  <a href="#meetup">近期行動</a>
+</nav>
+
+<section class="infr-opening infr-shell" aria-labelledby="infr-opening-title">
+  <p class="infr-kicker">從一次連線開始</p>
+  <h2 id="infr-opening-title">你看到網頁的這一刻，<br>資料已經經過許多人的手。</h2>
+  <div class="infr-opening__copy">
+    <p>你輸入網址，裝置先詢問網站在哪裡，再向伺服器索取內容。這段短短幾秒的路程，經過電信網路、DNS、平台與跨國海纜。每一站都可能影響你能不能抵達，也可能留下紀錄。</p>
+    <p>網路自由關注人們能否使用網路取得資訊、表達意見與組織行動，同時免於不當監控、審查與差別待遇。</p>
+  </div>
+</section>
+
+<section id="journey" class="infr-journey" aria-labelledby="infr-journey-title">
+  <div class="infr-journey__visual" aria-hidden="true">
+    <div class="infr-packet-map">
+      <div class="infr-packet-map__label">一次連線</div>
+      <svg viewBox="0 0 720 540" role="presentation">
+        <path class="infr-packet-map__path" d="M80 420 C155 420 153 306 244 306 S332 202 425 202 S525 112 642 112"></path>
+        <path class="infr-packet-map__progress" d="M80 420 C155 420 153 306 244 306 S332 202 425 202 S525 112 642 112"></path>
+        <g class="infr-map-node" data-node="0" transform="translate(80 420)"><circle r="15"></circle><text y="43">你的裝置</text></g>
+        <g class="infr-map-node" data-node="1" transform="translate(244 306)"><circle r="15"></circle><text y="43">DNS</text></g>
+        <g class="infr-map-node" data-node="2" transform="translate(425 202)"><circle r="15"></circle><text y="43">網路與平台</text></g>
+        <g class="infr-map-node" data-node="3" transform="translate(642 112)"><circle r="15"></circle><text y="43">目的地</text></g>
+      </svg>
+      <p class="infr-packet-map__status">輸入網址，準備送出請求</p>
     </div>
-</div>
-<p>
-    <a href="https://groups.google.com/g/coffee-circumvention-tw" target="_blank">
-        <i class="globe icon"></i>
-        網路自由小聚線上論壇
-    </a>
-</p>
+  </div>
+  <div class="infr-journey__steps">
+    <header class="infr-journey__intro">
+      <p class="infr-kicker">一則訊息如何抵達</p>
+      <h2 id="infr-journey-title">連得上，是許多條件暫時都成立。</h2>
+    </header>
+    <article class="infr-step is-active" data-stage="0" data-status="輸入網址，準備送出請求">
+      <span>01</span><h3>你發出請求</h3>
+      <p>瀏覽器需要知道網站所在的 IP 位址。這個查詢通常會交給 DNS 服務處理。</p>
+    </article>
+    <article class="infr-step" data-stage="1" data-status="DNS 正在回答網站位址">
+      <span>02</span><h3>有人替網路指路</h3>
+      <p>DNS 像網路的地址簿。錯誤回覆、攔截查詢或修改紀錄，都可能讓使用者找不到原本的網站。</p>
+    </article>
+    <article class="infr-step" data-stage="2" data-status="請求通過網路與平台規則">
+      <span>03</span><h3>沿途可以觀察，也能阻擋</h3>
+      <p>電信業者、平台與政府各自掌握不同的技術和權力。限速、封鎖、內容下架與流量監控，可能發生在不同位置。</p>
+    </article>
+    <article class="infr-step" data-stage="3" data-status="訊息抵達，但自由仍需要被守住">
+      <span>04</span><h3>抵達不代表問題消失</h3>
+      <p>連線成功之後，個資如何被蒐集、演算法如何決定內容能見度、使用者能否申訴，仍會影響每個人的數位權利。</p>
+    </article>
+  </div>
+</section>
 
-<p>
-    <a href="https://ocftw.kktix.cc/" target="_blank">
-        <i class="globe icon"></i>
-        網路自由小聚活動
-    </a>
-</p>
-<p>
-    <a href="https://hackmd.io/efBMZl4ITImkxUOjlmByHg?view" target="_blank">
-        <i class="globe icon"></i>
-        網路自由小聚活動共筆
-    </a>
-</p>
-<p>
-    <a href="https://youtu.be/04fsSK3q7Oo?si=iNItWnSuPDtELc-J" target="_blank">
-        <i class="globe icon"></i>
-        網路自由小劇場 Podcast
-    </a>
-</p>
+<section id="topics" class="infr-topics infr-shell" aria-labelledby="infr-topics-title">
+  <div class="infr-section-heading">
+    <p class="infr-kicker">問題離生活很近</p>
+    <h2 id="infr-topics-title">網路自由受到哪些壓力？</h2>
+    <p>封鎖只是其中一種形式。日常使用的服務、裝置與制度，都會改變人們在網路上的處境。</p>
+  </div>
+  <div class="infr-topic-grid">
+    <article class="infr-topic-card infr-topic-card--censorship">
+      <span class="infr-topic-card__number">01</span><div class="infr-topic-card__signal" aria-hidden="true"></div>
+      <h3>網路封鎖與審查</h3><p>網站突然無法開啟，可能來自 DNS、IP、關鍵字或整段網路的封鎖。測量工具能協助我們分辨技術故障與人為干預。</p>
+      <a href="/p/ooni/">認識 OONI <span aria-hidden="true">→</span></a>
+    </article>
+    <article class="infr-topic-card infr-topic-card--privacy">
+      <span class="infr-topic-card__number">02</span><div class="infr-topic-card__signal" aria-hidden="true"></div>
+      <h3>隱私與監控</h3><p>瀏覽紀錄、位置、聯絡人與生物特徵都能拼出一個人的生活。資料蒐集需要清楚界線，也需要真正可行的拒絕方式。</p>
+      <a href="/p/eid/">閱讀數位身分案例 <span aria-hidden="true">→</span></a>
+    </article>
+    <article class="infr-topic-card infr-topic-card--platform">
+      <span class="infr-topic-card__number">03</span><div class="infr-topic-card__signal" aria-hidden="true"></div>
+      <h3>平台權力</h3><p>內容排序、下架與帳號停權會改變公共討論。規則需要透明，受到錯誤處置的人也需要有效的申訴管道。</p>
+      <a href="/p/issues/">查看議題倡議 <span aria-hidden="true">→</span></a>
+    </article>
+    <article class="infr-topic-card infr-topic-card--resilience">
+      <span class="infr-topic-card__number">04</span><div class="infr-topic-card__signal" aria-hidden="true"></div>
+      <h3>網路韌性</h3><p>海纜、基地台與資料中心都可能中斷。災害或政治危機發生時，通訊備援與開放工具會直接影響人們能否互相找到。</p>
+      <a href="#meetup">查看相關小聚 <span aria-hidden="true">→</span></a>
+    </article>
+  </div>
+</section>
 
-<p>
-    <a href="https://www.youtube.com/watch?v=ek2XjW7Q3wI&list=PLFuYOsppHDrlYquISvSfOjrT5g_mjMGot" target="_blank">
-        <i class="globe icon"></i>
-        網路自由小聚 2024 Recap
-    </a>
-</p>
+<section id="work" class="infr-work" aria-labelledby="infr-work-title">
+  <div class="infr-shell">
+    <div class="infr-section-heading infr-section-heading--light">
+      <p class="infr-kicker">把關心變成行動</p>
+      <h2 id="infr-work-title">OCF 如何守住網路自由</h2>
+      <p>技術問題需要測量，政策爭議需要追蹤，使用工具的人也需要互相交換經驗。我們讓這些工作在台灣持續發生。</p>
+    </div>
+    <div class="infr-work-grid">
+      <article><strong>測量</strong><h3>留下網路審查的證據</h3><p>推廣 OONI，協助更多人理解測量資料，辨認網站封鎖與連線異常。</p><a href="/p/ooni/">查看 OONI 專案</a></article>
+      <article><strong>討論</strong><h3>讓艱難議題有人能問</h3><p>網路自由小聚從 2019 年開始，持續討論隱私、平台治理、AI、通訊安全與網路韌性。</p><a href="#meetup">查看近期主題</a></article>
+      <article><strong>倡議</strong><h3>把公民觀點帶進政策現場</h3><p>追蹤數位治理與人權爭議，透過文章、聲明、會議參與及跨組織合作提出意見。</p><a href="/p/issues/">閱讀倡議工作</a></article>
+      <article><strong>串連</strong><h3>讓台灣加入國際對話</h3><p>參與 RightsCon、DRAPAC、IETF 與 OONI 社群，把在地經驗帶出去，也把國際方法帶回來。</p><a href="/p/global/">查看國際交流</a></article>
+    </div>
+    <div class="infr-history" aria-label="網路自由工作時間軸">
+      <div><time>2019</time><p>台北網路自由小聚開始，每月聚集關心數位權利的人。</p></div>
+      <div><time>2023</time><p>從 OONI、AI 到數位韌性，議題跨進更多生活與政策現場。</p></div>
+      <div><time>2025</time><p>RightsCon 在台北舉行，台灣公民社會與全球數位人權社群相遇。</p></div>
+      <div><time>2026</time><p>持續追問海纜、平台管制、災防通訊與身分資料帶來的新問題。</p></div>
+    </div>
+  </div>
+</section>
+
+{% assign current_event = site.data.p.infr.events | first %}
+<section id="meetup" class="infr-meetup infr-shell" aria-labelledby="infr-meetup-title">
+  <div class="infr-meetup__intro">
+    <p class="infr-kicker">Coffee &amp; Circumvention</p>
+    <h2 id="infr-meetup-title">下一個問題，帶來小聚一起拆。</h2>
+    <p>每個月第三個星期四，我們邀請技術工作者、研究者、記者、學生與一般使用者，從具體事件理解網路自由。</p>
+    <a class="infr-button infr-button--dark" href="https://ocftw.kktix.cc/" target="_blank" rel="noopener">查看最新活動</a>
+  </div>
+  <div class="infr-meetup__topics">
+    <p class="infr-meetup__year">2026 討論主題</p>
+    <ol>
+      {% for link in current_event.links %}
+      <li><a href="{{ link.url }}" target="_blank" rel="noopener"><span>{{ forloop.index | prepend: '0' }}</span>{{ link.title }}</a></li>
+      {% endfor %}
+    </ol>
+    <div class="infr-resource-links">
+      <a href="https://hackmd.io/efBMZl4ITImkxUOjlmByHg?view" target="_blank" rel="noopener">歷次活動共筆</a>
+      <a href="https://groups.google.com/g/coffee-circumvention-tw" target="_blank" rel="noopener">加入線上論壇</a>
+      <a href="https://www.youtube.com/watch?v=ek2XjW7Q3wI&amp;list=PLFuYOsppHDrlYquISvSfOjrT5g_mjMGot" target="_blank" rel="noopener">觀看活動影片</a>
+    </div>
+  </div>
+</section>
+
+<section class="infr-closing" aria-labelledby="infr-closing-title">
+  <div class="infr-closing__signal" aria-hidden="true"><span></span></div>
+  <div class="infr-shell">
+    <p class="infr-kicker">Keep the internet open</p>
+    <h2 id="infr-closing-title">自由的網路，需要有人持續測量、追問與行動。</h2>
+    <p>讓下一次連線，也能抵達它原本要去的地方。</p>
+    <div class="infr-closing__actions">
+      <a class="infr-button" href="https://ocf.tw/300/" target="_blank" rel="noopener">捐款支持 OCF</a>
+      <a class="infr-text-link" href="https://ocftw.kktix.cc/" target="_blank" rel="noopener">參加網路自由小聚 <span aria-hidden="true">→</span></a>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## What changed

- add `/internet-freedom/` as a standalone, knowledge-led issue page
- add Internet Freedom to the main menu under Core Advocacy
- use a dedicated layout without project metadata or the project sidebar
- add a scroll-driven explanation of how an internet connection can be observed or blocked
- add issue primers, OCF work highlights, a timeline, current meetup topics, and participation links
- restore `/p/infr/` as the regular Internet Freedom project and activity page

## Why

Internet freedom is a long-term issue that OCF needs to explain independently of any single project. The standalone page gives new visitors a clear introduction to the issue, while the existing project page continues to hold activities and project records.

## Validation

- `bundle exec jekyll build --destination /tmp/ocf-internet-freedom-standalone`
- verified `/internet-freedom/` uses the standalone layout without project metadata
- verified the Core Advocacy menu links to `/internet-freedom/`
- verified `/p/infr/` retains the project sidebar and event list
- verified no horizontal overflow or browser console warnings

This PR is intentionally left as a draft and should not be merged until the content and menu placement are reviewed.
