### PR TITLE
Add new job openings

### DIFF
--- a/hiring.html
+++ b/hiring.html
@@ -396,6 +396,253 @@ toc: false
         <details class="job-card">
             <summary class="job-summary">
                 <div class="job-title-group">
+                    <h2>專案經理</h2>
+                    <div class="tags">
+                        <span class="tag">全職</span>
+                        <span class="tag">專案管理</span>
+                        <span class="tag salary">42k+</span>
+                    </div>
+                    <p style="font-size: 0.8rem; color: #a0aec0; margin: 8px 0 0 0;">更新時間：2026/8/5</p>
+                </div>
+                <div class="toggle-icon">▼</div>
+            </summary>
+
+            <div class="job-content">
+                <div class="overview-box">
+                    <p><strong>OCF 與國內外非營利組織有許多合作，同時持續爭取各方補助及政府標案。</strong></p>
+                    <p>專案經理將負責管理中型以上的跨領域專案、協調多方利害關係人，並確保資源得到最有效率的配置。</p>
+                    <p>這個職位也需要對外發聲，代表組織出席各種國內與國際會議。在高變動性的環境中，持續透過各開放領域的專案發展推動組織核心目標。</p>
+                </div>
+
+                <div class="section-block">
+                    <h3>工作內容</h3>
+                    <ul>
+                        <li>負責開放文化相關專案的總體規劃、申請、執行及結案報告撰寫。</li>
+                        <li>負責專案預算、成本控管及相關帳務處理。</li>
+                        <li>處理跨領域利害關係人溝通，了解多方期望，媒合技術資源、社會需求與 OCF 目標。</li>
+                        <li>對外接洽及開發新的合作組織，代表基金會參與國內或國際會議。</li>
+                        <li>統籌專案團隊並引導成員有效協作，協助排解執行過程中的障礙，促進團隊成員的專業成長。</li>
+                    </ul>
+                </div>
+
+                <div class="section-block">
+                    <h3>能力要求</h3>
+                    <ul>
+                        <li><strong>核心能力：</strong>
+                            <ul>
+                                <li>具 2 年以上專案管理經驗，有獨立控管預算與專案時程的實績。</li>
+                                <li>具良好的抗壓性與彈性，能冷靜應變，解決專案進行過程中遇到的狀況。</li>
+                                <li>能以英文進行口語、書信溝通與交談，掌握專案文件需求並撰寫報告。</li>
+                                <li>具團隊統籌分工與溝通能力，能與不同背景領域的夥伴溝通協調，完成專案目標。</li>
+                            </ul>
+                        </li>
+                        <li><strong>加分能力：</strong>
+                            <ul>
+                                <li>曾帶領 3 人以上的專案小組完成專案。</li>
+                                <li>具備爭取外部資源的成功經驗，如政府採購案招標、國際基金會 Grant 申請。</li>
+                                <li>有 NPO/NGO、社會運動或開源社群參與經驗。</li>
+                                <li>對臺灣數位治理議題或開源法規政策有涉獵。</li>
+                                <li>對國際數位治理議題或開源法規政策有涉獵（如 EU AI Act、CRA、DSA 等）。</li>
+                                <li>其他特殊能力、語言專長或特殊經歷，也歡迎讓我們知道！</li>
+                            </ul>
+                        </li>
+                    </ul>
+                </div>
+
+                <div class="section-block">
+                    <h3>薪資待遇</h3>
+                    <p>月薪：42,000 元以上（面議）。本會依學經歷及相關工作經驗敘薪，具豐富相關經驗者，薪資可另議。來信請附期望待遇。</p>
+                    <ul>
+                        <li>享三節禮金、員工團保。</li>
+                        <li>將依基金會營運狀況發放年終獎金，另可依董事會核可享電腦補助與每年至多七日福利假。</li>
+                    </ul>
+                </div>
+
+                <div class="apply-box">
+                    <h3>🚀 申請方式</h3>
+                    <p>請將必備文件寄至 hr@ocf.tw，標題請寫『我要加入OCF_專案經理_姓名』並附期望待遇。</p>
+                    <p>履歷隨到隨審，若不符合資格，恕不另行通知。</p>
+
+                    <div style="background: rgba(255,255,255,0.1); padding: 15px; border-radius: 6px; margin: 15px 0;">
+                        <ul style="margin-bottom: 0;">
+                            <strong>必備文件：</strong>
+                            <li>履歷（PDF）</li>
+                            <li>能呈現專案管理、預算控管、資源開發或跨領域團隊統籌經驗的相關資料。</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </details>
+
+        <details class="job-card">
+            <summary class="job-summary">
+                <div class="job-title-group">
+                    <h2>專案管理師（開放科技）</h2>
+                    <div class="tags">
+                        <span class="tag">全職</span>
+                        <span class="tag">開放科技</span>
+                        <span class="tag salary">38-42k</span>
+                    </div>
+                    <p style="font-size: 0.8rem; color: #a0aec0; margin: 8px 0 0 0;">更新時間：2026/8/5</p>
+                </div>
+                <div class="toggle-icon">▼</div>
+            </summary>
+
+            <div class="job-content">
+                <div class="overview-box">
+                    <p><strong>你將主要負責 OCF「開放科技」領域的專案。</strong></p>
+                    <p>專案議題涵蓋開放原始碼、開放資料與開放政府。具體專案內容包括法規與倡議、開源應用、軟硬體導入、開源生態系發展等。</p>
+                    <p>你會與在地及國際的開源社群、公民團體、政府單位協力合作，將科技概念轉化為公眾能理解的推廣與實作行動。</p>
+                </div>
+
+                <div class="section-block">
+                    <h3>工作內容</h3>
+                    <p><strong>一、專案管理與日常推進</strong></p>
+                    <ul>
+                        <li>參與專案從開啟、運作到結案的完整生命週期。</li>
+                        <li>執行開放科技相關專案、籌備與辦理活動，參與報告撰寫與規劃。</li>
+                        <li>維護專案相關文件與紀錄。</li>
+                        <li>負責日常聯絡、進度追蹤，以及其他主管交辦與專案支援事項。</li>
+                    </ul>
+
+                    <p><strong>二、跨域倡議與串聯</strong></p>
+                    <ul>
+                        <li>促進社群、NGO、政府部門與企業之間的多方對話協力。</li>
+                        <li>推廣議題轉化，將科技議題（如個資保護、AI 倫理、公私部門協力、開源授權等）轉化為易懂的大眾溝通內容。</li>
+                        <li>視專案需求，代表組織出席外部開放科技會議。</li>
+                        <li>深化與國內外科技與倡議組織、公私部門及開源社群的合作網絡。</li>
+                    </ul>
+                </div>
+
+                <div class="section-block">
+                    <h3>能力要求</h3>
+                    <ul>
+                        <li><strong>核心能力：</strong>
+                            <ul>
+                                <li>具備專案執行、進度追蹤、文件整理與跨團隊協作能力。</li>
+                                <li>能清楚維護會議紀錄、專案文件、預算與工作項目狀態。</li>
+                                <li>認同開放原始碼、開放資料、開放政府、數位人權與網路自由等價值。</li>
+                                <li>具 1 至 2 年專案管理或活動企劃經驗。</li>
+                                <li>對開放原始碼（Open Source）、開放資料、個人隱私議題有基本認識，並願進一步了解。</li>
+                                <li>具良好的中英文讀寫與口語表達能力，能流暢地與不同背景的夥伴溝通。</li>
+                            </ul>
+                        </li>
+                        <li><strong>加分能力：</strong>
+                            <ul>
+                                <li>具議題研究、報告撰寫、政策倡議或公部門專案執行經驗。</li>
+                                <li>有非營利組織、開源社群、公民科技、跨領域專案的合作或任職經驗。</li>
+                                <li>對國際數位治理議題或開源法規政策有涉獵（如 EU AI Act、CRA 等）。</li>
+                            </ul>
+                        </li>
+                    </ul>
+                </div>
+
+                <div class="section-block">
+                    <h3>薪資待遇</h3>
+                    <p>月薪：38,000 - 42,000 元。本會依學經歷及相關工作經驗敘薪，具豐富相關經驗者，薪資可另議。來信請附期望待遇。</p>
+                    <ul>
+                        <li>享三節禮金、員工團保。</li>
+                        <li>將依基金會營運狀況發放年終獎金，另可依董事會核可享電腦補助與每年至多七日福利假。</li>
+                    </ul>
+                </div>
+
+                <div class="apply-box">
+                    <h3>🚀 申請方式</h3>
+                    <p>請將必備文件寄至 hr@ocf.tw，標題請寫『我要加入OCF_專案管理師（開放科技）_姓名』並附期望待遇。</p>
+                    <p>履歷隨到隨審，若不符合資格，恕不另行通知。</p>
+
+                    <div style="background: rgba(255,255,255,0.1); padding: 15px; border-radius: 6px; margin: 15px 0;">
+                        <ul style="margin-bottom: 0;">
+                            <strong>必備文件：</strong>
+                            <li>履歷（PDF）</li>
+                            <li>能呈現專案執行、活動企劃、議題研究、倡議溝通或跨領域合作經驗的相關資料。</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </details>
+
+        <details class="job-card">
+            <summary class="job-summary">
+                <div class="job-title-group">
+                    <h2>行政營運管理師</h2>
+                    <div class="tags">
+                        <span class="tag">全職</span>
+                        <span class="tag">行政營運</span>
+                        <span class="tag salary">36-40k</span>
+                    </div>
+                    <p style="font-size: 0.8rem; color: #a0aec0; margin: 8px 0 0 0;">更新時間：2026/8/5</p>
+                </div>
+                <div class="toggle-icon">▼</div>
+            </summary>
+
+            <div class="job-content">
+                <div class="overview-box">
+                    <p><strong>本職務屬營運部門，主要協助社群服務與營運相關事務。</strong></p>
+                    <p>OCF 長期與許多臺灣開源社群合作，提供行政金流服務並協助開源社群發展。基金會推動各項開放文化工作，也需要強大的營運團隊支持後勤運作。</p>
+                </div>
+
+                <div class="section-block">
+                    <h3>工作內容</h3>
+                    <ul>
+                        <li>擔任社群支援與聯繫窗口，處理金流與行政法人服務，如經費核銷、單據開立、合約檢視、金流資訊整理等。</li>
+                        <li>建立與維繫社群關係，出席社群活動、了解需求並發想新的合作方式。</li>
+                        <li>執行辦公室行政與營運事務管理，協助相關行政庶務及會務聯繫。</li>
+                        <li>支援基金會業務推廣活動。</li>
+                    </ul>
+                </div>
+
+                <div class="section-block">
+                    <h3>能力要求</h3>
+                    <ul>
+                        <li><strong>核心能力：</strong>
+                            <ul>
+                                <li>具備電話口說與 Email 撰寫禮儀、良好的文字溝通與表達能力，不害怕與人互動。</li>
+                                <li>具 1 年以上行政、出納、人事或助理相關工作經驗，能獨立思考與解決問題。</li>
+                                <li>細心、對數字具敏感度，能有條理地處理繁雜事務與流程。</li>
+                                <li>熟悉 Google Workspace 等線上協作工具。</li>
+                                <li>能主動發現流程問題，並具備嘗試調整的彈性。</li>
+                            </ul>
+                        </li>
+                        <li><strong>加分能力：</strong>
+                            <ul>
+                                <li>曾參與或接觸開源社群，理解社群協作文化。</li>
+                                <li>有 NPO/NGO、社會運動或開源社群參與經驗。</li>
+                                <li>有使用 AI 協助工作或改良行政流程的經驗。</li>
+                                <li>其他特殊能力、語言專長或特殊經歷，也歡迎讓我們知道！</li>
+                            </ul>
+                        </li>
+                    </ul>
+                </div>
+
+                <div class="section-block">
+                    <h3>薪資待遇</h3>
+                    <p>月薪：36,000 - 40,000 元。本會依學經歷及相關工作經驗敘薪，具豐富相關經驗者，薪資可另議。來信請附期望待遇。</p>
+                    <ul>
+                        <li>享三節禮金、員工團保。</li>
+                        <li>將依基金會營運狀況發放年終獎金，另可依董事會核可享電腦補助與每年至多七日福利假。</li>
+                    </ul>
+                </div>
+
+                <div class="apply-box">
+                    <h3>🚀 申請方式</h3>
+                    <p>請將必備文件寄至 hr@ocf.tw，標題請寫『我要加入OCF_行政營運管理師_姓名』並附期望待遇。</p>
+                    <p>履歷隨到隨審，若不符合資格，恕不另行通知。</p>
+
+                    <div style="background: rgba(255,255,255,0.1); padding: 15px; border-radius: 6px; margin: 15px 0;">
+                        <ul style="margin-bottom: 0;">
+                            <strong>必備文件：</strong>
+                            <li>履歷（PDF）</li>
+                            <li>能呈現行政營運、金流處理、流程改善或社群協作經驗的相關資料。</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </details>
+
+        <details class="job-card">
+            <summary class="job-summary">
+                <div class="job-title-group">
                     <h2>募款與企業合作專員</h2>
                     <div class="tags">
                         <span class="tag urgent">半年期職務代理</span>


### PR DESCRIPTION
## What changed

- Add the project manager opening.
- Add the open technology project coordinator opening.
- Add the administrative operations coordinator opening.
- Include responsibilities, qualifications, compensation, benefits, and application instructions for each role.

## Why

Publish the latest OCF openings on `ocf.tw/jobs` using the existing expandable job-card layout.

## Validation

- `git diff --check`
- `bundle exec jekyll build --destination /tmp/ocf-website-build`
