### PR TITLE
改善電子報訂閱區響應式版面

### DIFF
--- a/assets/styles/news.css
+++ b/assets/styles/news.css
@@ -1,11 +1,3 @@
-#news .mobile {
-  display: none;
-}
-
-#news .mobile .buttons {
-  background-color: rgba(255, 255, 255, 0.8);
-}
-
 #news #newsletters .header {
   cursor: pointer;
 }
@@ -16,13 +8,94 @@
   line-height: 1.75em;
 }
 
+#news .subscribe-card {
+  padding: 2rem;
+  border: 0;
+  border-radius: 0.85rem;
+  background: var(--ocf-light);
+  box-shadow: 0 0.35rem 1.5rem rgba(31, 37, 64, 0.1);
+}
+
+#news .subscribe-card > .header {
+  margin-bottom: 0.5rem;
+  color: var(--ocf-primary);
+  font-size: 1.65rem;
+}
+
+#news .subscribe-intro {
+  margin: 0 0 1.5rem;
+  color: rgba(0, 0, 0, 0.7);
+  line-height: 1.65;
+}
+
+#news .subscribe-card .field > label,
+#news .subscribe-card .ui.checkbox label {
+  color: rgba(0, 0, 0, 0.78);
+}
+
+#news .subscribe-card input[type="text"],
+#news .subscribe-card input[type="email"] {
+  min-height: 3rem;
+}
+
+#news .subscribe-actions {
+  display: grid;
+  gap: 1rem;
+}
+
+#news .recaptcha-wrap {
+  max-width: 100%;
+  overflow: hidden;
+}
+
+#news #_qf_Edit_next {
+  width: 100%;
+  min-height: 3rem;
+  margin: 0;
+  background-color: var(--ocf-primary);
+  color: var(--ocf-white);
+  font-size: 1rem;
+}
+
+#news #_qf_Edit_next:hover,
+#news #_qf_Edit_next:focus {
+  filter: brightness(0.9);
+}
+
+#news .privacy-note {
+  margin: 1rem 0 0;
+  color: rgba(0, 0, 0, 0.55);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
 @media only screen and (max-width: 767px) {
-  #news .mobile {
-    display: initial;
+  #news .news-layout {
+    display: flex;
+    flex-direction: column;
+  }
+
+  #news .subscribe-column {
+    order: -1;
+  }
+
+  #news .subscribe-card {
+    position: static !important;
+    padding: 1.5rem;
+    margin-bottom: 1rem;
   }
 
   #news #newsletters .header .icon {
     float: none;
     line-height: 0.85em;
+  }
+}
+
+@media only screen and (max-width: 359px) {
+  #news .recaptcha-wrap .g-recaptcha {
+    width: 116.3%;
+    height: 67px;
+    transform: scale(0.86);
+    transform-origin: left top;
   }
 }

--- a/news/index.html
+++ b/news/index.html
@@ -34,26 +34,9 @@ years:
   {% include _shared/kv.html title= page.og_title
     description= page.og_slogn image="/assets/images/news_KV.png" %}
 
-  <div class="ui center aligned stripe container">
-    <div class="mobile">
-      <div class="ui two sticky basic buttons">
-        <a href="#subscribe"
-           class="ui button">
-          <i class="icon mail outline"></i>
-          訂閱
-        </a>
-        <a href="#news"
-           class="ui button">
-          <i class="icon up arrow"></i>
-          回頁首
-        </a>
-      </div>
-    </div>
-  </div>
-
   <div class="ui stripe container">
-    <div class="ui two column stackable grid">
-      <div class="ten wide column">
+    <div class="ui two column stackable grid news-layout">
+      <div class="ten wide column newsletter-column">
 
         <section id="newsletters">
 
@@ -97,20 +80,22 @@ years:
 
         </section>
       </div>
-      <div class="six wide column">
+      <div class="six wide column subscribe-column">
         <section id="subscribe"
-                 class="ui sticky secondary basic segment" style="background-color: var(--ocf-light);">
-          <h2 class="ui center aligned small icon header">
-            <i class="mail outline icon"></i>
+                 class="ui sticky segment subscribe-card">
+          <h2 class="ui header">
             訂閱電子報
           </h2>
+          <p class="subscribe-intro">
+            每月收到開源社群消息、數位人權議題與 OCF 近期活動。
+          </p>
           <form class="ui form"
                 action="https://ocf.neticrm.tw/civicrm/profile/create?gid=12&amp;reset=1"
                 method="post"
                 name="Edit"
                 id="Edit">
             <div class="required field">
-              <label for="last_name" style="color: var(--ocf-primary);">姓氏</label>
+              <label for="last_name">姓氏</label>
               <input type="text"
                      name="last_name"
                      id="last_name"
@@ -118,7 +103,7 @@ years:
                      required />
             </div>
             <div class="required field">
-              <label for="first_name" style="color: var(--ocf-primary);">名字</label>
+              <label for="first_name">名字</label>
               <input type="text"
                      name="first_name"
                      id="first_name"
@@ -126,7 +111,7 @@ years:
                      required />
             </div>
             <div class="required field">
-              <label for="email-Primary" style="color: var(--ocf-primary);">電子信箱</label>
+              <label for="email-Primary">電子信箱</label>
               <input type="email"
                      name="email-Primary"
                      id="email-Primary"
@@ -140,21 +125,22 @@ years:
                        name="group[2]"
                        value="1"
                        checked />
-                <label style="color: var(--ocf-primary);">我要訂閱電子報</label>
+                <label>我要訂閱電子報</label>
               </div>
             </div>
-            <div style="display: flex; justify-content: space-around; align-items: center;">
-            <p class="g-recaptcha"
-               data-sitekey="6LedpB4TAAAAAEubH6xXlcjLa1D8jXzMVMG6Q3J2">
-            </p>
+            <div class="subscribe-actions">
+              <div class="recaptcha-wrap">
+                <div class="g-recaptcha"
+                     data-sitekey="6LedpB4TAAAAAEubH6xXlcjLa1D8jXzMVMG6Q3J2">
+                </div>
+              </div>
               <button class="ui submit button"
-              name="_qf_Edit_next"
-              value="訂閱"
-              type="submit"
-              id="_qf_Edit_next"
-              style="background-color: var(--ocf-primary); color: var(--ocf-white);"
-              >訂閱</button>
+                      name="_qf_Edit_next"
+                      value="訂閱"
+                      type="submit"
+                      id="_qf_Edit_next">訂閱電子報</button>
             </div>
+            <p class="privacy-note">你可以隨時取消訂閱。我們會妥善保管你的資料。</p>
             <script src="//www.google.com/recaptcha/api.js"></script>
 
           </form>


### PR DESCRIPTION
## 修改內容

- 手機版將訂閱表單移到電子報列表之前
- 重整訂閱卡片、欄位、說明文字與主要按鈕的視覺層級
- 將 reCAPTCHA 與提交按鈕改為上下排列，避免窄螢幕溢出
- 移除手機版原有的訂閱／回頁首工具列

## 原因

原本的雙欄版面在手機上堆疊後，訂閱表單會落到所有歷年電子報之後。reCAPTCHA 與按鈕並排也容易超出窄螢幕。

## 驗證

- `bundle exec jekyll build --destination /tmp/ocf-news-preview`
- 本機預覽檢查 320px、390px、1280px
- 三種寬度均無水平溢出，桌機維持左右欄排列
